### PR TITLE
Use Camcorder to mock IMAP and SMTP

### DIFF
--- a/gmail.gemspec
+++ b/gmail.gemspec
@@ -15,16 +15,17 @@ Gem::Specification.new do |s|
   s.authors = ["Chris Kowalik"]
   s.email = ["chris@nu7hat.ch"]
   s.homepage = "http://github.com/nu7hatch/gmail"
-  
+
   # runtime dependencies
   s.add_dependency "mail", ">= 2.2.1"
   s.add_dependency "gmail_xoauth", ">= 0.3.0"
-  
+
   # development dependencies
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", ">= 3.1"
+  s.add_development_dependency "camcorder"
   s.add_development_dependency "gem-release"
-  
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe "Gmail client (Plain)" do
   subject { Gmail::Client::Plain }
-  
+
   context "on initialize" do
     it "should set username, password and options" do
       client = subject.new("test@gmail.com", "pass", :foo => :bar)
@@ -10,15 +10,15 @@ describe "Gmail client (Plain)" do
       client.password.should == "pass"
       client.options[:foo].should == :bar
     end
-    
-    it "should convert simple name to gmail email" do 
+
+    it "should convert simple name to gmail email" do
       client = subject.new("test", "pass")
       client.username.should == "test@gmail.com"
     end
   end
-  
-  context "instance" do   
-    it "should connect to GMail IMAP service" do 
+
+  context "instance" do
+    it "should connect to GMail IMAP service" do
       client = mock_client
       client.connect!.should be_truthy
     end
@@ -30,16 +30,16 @@ describe "Gmail client (Plain)" do
       client.should be_logged_in
       client.logout
     end
-    
+
     it "should raise error when given GMail account is invalid and errors enabled" do
       lambda {
         client = Gmail::Client::Plain.new("foo", "bar")
         client.connect.should be_truthy
         client.login!.should_not be_nil
-        }.should raise_error      
+        }.should raise_error
         ### FIX: can someone dig to the bottom of this?  We are getting NoMethodError instead of Gmail::Client::AuthorizationError in 1.9
     end
-    
+
     it "shouldn't raise error even though GMail account is invalid" do
       lambda {
         client = Gmail::Client::Plain.new("foo", "bar")
@@ -53,23 +53,23 @@ describe "Gmail client (Plain)" do
       client.connect.should be_truthy
       client.login.should be_falsey
     end
-    
-    it "should properly logout from GMail" do 
+
+    it "should properly logout from GMail" do
       client = mock_client
       client.connect
       client.login.should be_truthy
       client.logout.should be_truthy
       client.should_not be_logged_in
     end
-    
+
     it "#connection should automatically log in to GMail account when it's called" do
       mock_client do |client|
         expect(client).to receive(:login).once.and_return(false)
         client.connection.should_not be_nil
       end
     end
-    
-    it "should properly compose message" do 
+
+    it "should properly compose message" do
       mail = mock_client.compose do
         from "test@gmail.com"
         to "friend@gmail.com"
@@ -79,7 +79,7 @@ describe "Gmail client (Plain)" do
       mail.to.should == ["friend@gmail.com"]
       mail.subject.should == "Hello world!"
     end
-    
+
     it "#compose should automatically add `from` header when it is not specified" do
       mail = mock_client.compose
       mail.from.should == [TEST_ACCOUNT[0]]
@@ -88,39 +88,39 @@ describe "Gmail client (Plain)" do
       mail = mock_client.compose {}
       mail.from.should == [TEST_ACCOUNT[0]]
     end
-    
+
     it "should deliver inline composed email" do
       mock_client do |client|
-        client.deliver do 
+        client.deliver do
           to TEST_ACCOUNT[0]
           subject "Hello world!"
           body "Yeah, hello there!"
         end.should be_truthy
       end
     end
-    
+
     it "should not raise error when mail can't be delivered and errors are disabled" do
-      lambda { 
+      lambda {
         client = mock_client
         client.deliver(Mail.new {}).should be false
       }.should_not raise_error
     end
-    
-    it "should raise error when mail can't be delivered and errors are disabled" do 
-      lambda { 
+
+    it "should raise error when mail can't be delivered and errors are disabled" do
+      lambda {
         client = mock_client
         client.deliver!(Mail.new {})
       }.should raise_error(Gmail::Client::DeliveryError)
     end
-    
+
     it "should properly switch to given mailbox" do
-      mock_client do |client| 
+      mock_client do |client|
         mailbox = client.mailbox("INBOX")
         mailbox.should be_kind_of(Gmail::Mailbox)
         mailbox.name.should == "INBOX"
-      end 
+      end
     end
-    
+
     it "should properly switch to given mailbox using block style" do
       mock_client do |client|
         client.mailbox("INBOX") do |mailbox|
@@ -129,25 +129,29 @@ describe "Gmail client (Plain)" do
         end
       end
     end
-    
+
     context "labels" do
-      subject { 
-        client = Gmail::Client::Plain.new(*TEST_ACCOUNT)
+      let(:client) { Gmail::Client::Plain.new(*TEST_ACCOUNT) }
+
+      subject {
         client.connect
+        client.login
         client.labels
       }
-      
+
+      after { client.logout if client.logged_in? }
+
       it "should get list of all available labels" do
         labels = subject
         labels.all.should include("INBOX")
       end
-      
+
       it "should be able to check if there is given label defined" do
         labels = subject
         labels.exists?("INBOX").should be true
         labels.exists?("FOOBAR").should be false
       end
-      
+
       it "should be able to create given label" do
         labels = subject
         labels.create("MYLABEL")
@@ -155,7 +159,7 @@ describe "Gmail client (Plain)" do
         labels.create("MYLABEL").should be false
         labels.delete("MYLABEL")
       end
-      
+
       it "should be able to remove existing label" do
         labels = subject
         labels.create("MYLABEL")

--- a/spec/client_xoauth2_spec.rb
+++ b/spec/client_xoauth2_spec.rb
@@ -20,7 +20,7 @@ describe "Gmail client (XOAuth2)" do
   end
 
   context "instance" do
-    def mock_client(&block) 
+    def mock_client(&block)
       client = Gmail::Client::XOAuth2.new(*TEST_ACCOUNT)
       if block_given?
         client.connect
@@ -30,7 +30,7 @@ describe "Gmail client (XOAuth2)" do
       client
     end
 
-    it "should connect to GMail IMAP service" do 
+    it "should connect to GMail IMAP service" do
       expect(->{
         client = mock_client
         client.connect!.should be_truthy
@@ -143,11 +143,15 @@ describe "Gmail client (XOAuth2)" do
     end
 
     context "labels" do
+      let(:client) { Gmail::Client::XOAuth2.new(*TEST_ACCOUNT) }
+
       subject {
-        client = Gmail::Client::XOAuth2.new(*TEST_ACCOUNT)
         client.connect
+        client.login
         client.labels
       }
+
+      after { client.logout if client.logged_in? }
 
       it "should get list of all available labels" do
         pending

--- a/spec/recordings/A_Gmail_mailbox/instance/should_be_able_to_count_all_emails.yml
+++ b/spec/recordings/A_Gmail_mailbox/instance/should_be_able_to_count_all_emails.yml
@@ -1,0 +1,84 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-select-952b2929efa40a77889483d7484c90ea: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0002 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  behavior: :return
+Net::IMAP-uid_search-0414665161856fc9b6075b4b6bdfd699: !ruby/object:Camcorder::Recording
+  value:
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 7
+  - 8
+  - 9
+  - 10
+  - 11
+  - 12
+  - 13
+  - 14
+  - 15
+  - 16
+  - 17
+  - 18
+  - 19
+  - 20
+  - 21
+  - 22
+  - 23
+  - 24
+  - 25
+  - 26
+  - 27
+  - 28
+  - 29
+  - 30
+  - 31
+  - 32
+  - 33
+  - 34
+  - 35
+  - 36
+  - 37
+  - 38
+  - 39
+  - 40
+  - 41
+  - 42
+  - 43
+  - 44
+  - 45
+  - 46
+  - 47
+  - 48
+  - 49
+  - 50
+  behavior: :return
+Net::IMAP-logout-ebf2631e2b49b74eebce3c3295b80560: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0004
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0004 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/A_Gmail_mailbox/instance/should_be_able_to_find_messages.yml
+++ b/spec/recordings/A_Gmail_mailbox/instance/should_be_able_to_find_messages.yml
@@ -1,0 +1,234 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-select-952b2929efa40a77889483d7484c90ea: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0002 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  behavior: :return
+Net::IMAP-uid_search-0414665161856fc9b6075b4b6bdfd699: !ruby/object:Camcorder::Recording
+  value:
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 7
+  - 8
+  - 9
+  - 10
+  - 11
+  - 12
+  - 13
+  - 14
+  - 15
+  - 16
+  - 17
+  - 18
+  - 19
+  - 20
+  - 21
+  - 22
+  - 23
+  - 24
+  - 25
+  - 26
+  - 27
+  - 28
+  - 29
+  - 30
+  - 31
+  - 32
+  - 33
+  - 34
+  - 35
+  - 36
+  - 37
+  - 38
+  - 39
+  - 40
+  - 41
+  - 42
+  - 43
+  - 44
+  - 45
+  - 46
+  - 47
+  - 48
+  - 49
+  - 50
+  behavior: :return
+Net::IMAP-select-f417c7c64e02204a00430f0e02dddcac: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0004
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0004 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  behavior: :return
+Net::IMAP-uid_fetch-91040fae3b676bd99b60f0e390d2faed: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::FetchData
+    seqno: 1
+    attr:
+      X-GM-MSGID: 1490339162618061913
+      X-GM-LABELS: []
+      UID: 1
+      FLAGS:
+      - :Seen
+      ENVELOPE: !ruby/struct:Net::IMAP::Envelope
+        date: Wed, 14 Jan 2015 21:03:01 -0800
+        subject: Three tips to get the most out of Gmail
+        from:
+        - !ruby/struct:Net::IMAP::Address
+          name: Gmail Team
+          route: 
+          mailbox: mail-noreply
+          host: google.com
+        sender:
+        - !ruby/struct:Net::IMAP::Address
+          name: Gmail Team
+          route: 
+          mailbox: mail-noreply
+          host: google.com
+        reply_to:
+        - !ruby/struct:Net::IMAP::Address
+          name: Gmail Team
+          route: 
+          mailbox: mail-noreply
+          host: google.com
+        to:
+        - !ruby/struct:Net::IMAP::Address
+          name: John Doe
+          route: 
+          mailbox: ki0zvkyi1yzgy7xu4f4dh46nqrcecm
+          host: gmail.com
+        cc: 
+        bcc: 
+        in_reply_to: 
+        message_id: "<CACNRAYKakHOCaxin=3D-9QAC=GRQgDae66vLpwqPQC6rDAJK2w@mail.gmail.com>"
+      BODY[]: "MIME-Version: 1.0\r\nx-no-auto-attachment: 1\r\nReceived: by 10.70.87.10;
+        Wed, 14 Jan 2015 21:03:01 -0800 (PST)\r\nDate: Wed, 14 Jan 2015 21:03:01 -0800\r\nMessage-ID:
+        <CACNRAYKakHOCaxin=3D-9QAC=GRQgDae66vLpwqPQC6rDAJK2w@mail.gmail.com>\r\nSubject:
+        Three tips to get the most out of Gmail\r\nFrom: Gmail Team <mail-noreply@google.com>\r\nTo:
+        John Doe <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nContent-Type: multipart/alternative;
+        boundary=bcaec51dcff73ca5e9050ca9c59a\r\n\r\n--bcaec51dcff73ca5e9050ca9c59a\r\nContent-Type:
+        text/plain; charset=UTF-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n
+        Three tips to get the most out of Gmail\r\n[image: Google]\r\n\r\nHi John\r\n\r\nTips
+        to get the most out of Gmail\r\n\r\n[image: Contacts]\r\nBring your contacts
+        and mail into Gmail\r\n\r\nOn your computer, you can copy your contacts and
+        emails from your old email\r\naccount to make the transition to Gmail even
+        better. Learn how\r\n<https://support.google.com/mail/answer/164640?hl=3Den&ref_topic=3D1669014>=\r\n.\r\n[image:
+        Search]\r\nFind what you need fast\r\n\r\nWith the power of Google Search
+        right in your inbox, it's easy to sort your\r\nemail. Find what you're looking
+        for with predictions based on email\r\ncontent, past searches and contacts.\r\n[image:
+        Search]\r\nMuch more than email\r\n\r\nYou can send text messages and make
+        video calls with Hangouts\r\n<https://www.google.com/intl/en/hangouts/> right
+        from Gmail. To use this\r\nfeature on mobile, download the Hangouts app for
+        Android\r\n<https://play.google.com/store/apps/details?id=3Dcom.google.android.talk&hl=\r\n=3Den>\r\nand
+        Apple <https://itunes.apple.com/en/app/hangouts/id643496868?mt=3D8>\r\ndevices.\r\n\r\n\r\n[image:
+        Gmail icon]Happy emailing,\r\nThe Gmail Team\r\n =C2=A9 2015 Google Inc. 1600
+        Amphitheatre Parkway, Mountain View, CA 94043\r\n\r\n--bcaec51dcff73ca5e9050ca9c59a\r\nContent-Type:
+        text/html; charset=UTF-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n<!DOCTYPE
+        html>\r\n<html><head><meta http-equiv=3D\"content-type\" content=3D\"text/html;charset=\r\n=3DUTF-8\"
+        /><title>Three tips to get the most out of Gmail</title></head><b=\r\nody
+        style=3D\"background-color:#e5e5e5; margin:20px 0;\"><br /><div style=3D\"=\r\nmargin:2%;\"><div
+        style=3D\"direction:ltr; text-align:left; font-family:'Open=\r\n sans','Arial',sans-serif;
+        color:#444; background-color:white; padding:1.5e=\r\nm; border-radius:1em;
+        box-shadow:1px -5px 8px 2px #bbb; max-width:580px; ma=\r\nrgin:2% auto 0 auto;\"><table
+        style=3D\"background:white;width:100%\"><tr><td>=\r\n<div style=3D\"width:90px;
+        height:54px; margin:10px auto;\"><img src=3D\"https=\r\n://services.google.com/fh/files/emails/google_logo_flat_90_color.png\"
+        alt=\r\n=3D\"Google\" width=3D\"90\" height=3D\"34\"/></div><div style=3D\"width:90%;
+        padd=\r\ning-bottom:10px; padding-left:15px\"><p><img alt=3D\"\" src=3D\"https://ssl.gst=\r\natic.com/accounts/services/mail/msa/gmail_icon_small.png\"
+        style=3D\"display:=\r\nblock; float:left; margin-top:4px; margin-right:5px;\"/><span
+        style=3D\"font-=\r\nfamily:'Open sans','Arial',sans-serif; font-weight:bold;
+        font-size:small; l=\r\nine-height:1.4em\">Hi John</span></p><p><span style=3D\"font-family:'Open
+        san=\r\ns','Arial',sans-serif; font-size:2.08em;\">Tips to get the most out
+        of Gmail=\r\n</span><br/></p></div><p></p><div style=3D\"float:left; clear:both;
+        padding:=\r\n0px 5px 10px 10px;\"><img src=3D\"https://services.google.com/fh/files/emails=\r\n/importcontacts.png\"
+        alt=3D\"Contacts\" style=3D\"display:block;\"width=3D\"129\"=\r\nheight=3D\"129\"/></div><div
+        style=3D\"float:left; vertical-align:middle; padd=\r\ning:10px; max-width:398px;
+        float:left;\"><table style=3D\"vertical-align:midd=\r\nle;\"><tr><td style=3D\"font-family:'Open
+        sans','Arial',sans-serif;\"><span st=\r\nyle=3D\"font-size:20px;\">Bring your
+        contacts and mail into Gmail</span><br/>=\r\n<br/><span style=3D\"font-size:small;
+        line-height:1.4em\">On your computer, y=\r\nou can copy your contacts and
+        emails from your old email account to make th=\r\ne transition to Gmail even
+        better. <a href=3D\"https://support.google.com/ma=\r\nil/answer/164640?hl=3Den&amp;ref_topic=3D1669014\"
+        style=3D\"text-decoration:=\r\nnone; color:#15C\">Learn how</a>.</span></td></tr></table></div><div
+        style=\r\n=3D\"float:left; clear:both; padding:0px 5px 10px 10px;\"><img src=3D\"https:/=\r\n/ssl.gstatic.com/mail/welcome/localized/en/welcome_search.png\"
+        alt=3D\"Searc=\r\nh\" style=3D\"display:block;\"width=3D\"129\"height=3D\"129\"/></div><div
+        style=3D=\r\n\"float:left; vertical-align:middle; padding:10px; max-width:398px;
+        float:le=\r\nft;\"><table style=3D\"vertical-align:middle;\"><tr><td style=3D\"font-family:'=\r\nOpen
+        sans','Arial',sans-serif;\"><span style=3D\"font-size:20px;\">Find what y=\r\nou
+        need fast</span><br/><br/><span style=3D\"font-size:small; line-height:1.=\r\n4em\">With
+        the power of Google Search right in your inbox, it's easy to sort=\r\n your
+        email. Find what you're looking for with predictions based on email c=\r\nontent,
+        past searches and contacts.</span></td></tr></table></div><div styl=\r\ne=3D\"float:left;
+        clear:both; padding:0px 5px 10px 10px;\"><img src=3D\"https:=\r\n//ssl.gstatic.com/accounts/services/mail/msa/welcome_hangouts.png\"
+        alt=3D\"S=\r\nearch\" style=3D\"display:block;\"width=3D\"129\"height=3D\"129\"/></div><div
+        styl=\r\ne=3D\"float:left; vertical-align:middle; padding:10px; max-width:398px;
+        floa=\r\nt:left;\"><table style=3D\"vertical-align:middle;\"><tr><td style=3D\"font-fami=\r\nly:'Open
+        sans','Arial',sans-serif;\"><span style=3D\"font-size:20px;\">Much mo=\r\nre
+        than email</span><br/><br/><span style=3D\"font-size:small; line-height:1=\r\n.4em\">You
+        can send text messages and make video calls with <a href=3D\"https=\r\n://www.google.com/intl/en/hangouts/\"
+        style=3D\"text-decoration:none; color:#=\r\n15C\">Hangouts</a> right from
+        Gmail. To use this feature on mobile, download=\r\n the Hangouts app for <a
+        href=3D\"https://play.google.com/store/apps/details=\r\n?id=3Dcom.google.android.talk&amp;hl=3Den\"
+        style=3D\"text-decoration:none; c=\r\nolor:#15C\">Android</a> and <a href=3D\"https://itunes.apple.com/en/app/hango=\r\nuts/id643496868?mt=3D8\"
+        style=3D\"text-decoration:none; color:#15C\">Apple</a=\r\n> devices.</span></td></tr></table></div><br/><br/>\r\n<div
+        style=3D\"clear:both; padding-left:13px; height:6.8em;\"><table style=3D=\r\n\"width:100%;
+        border-collapse:collapse; border:0\"><tr><td style=3D\"width:68p=\r\nx\"><img
+        alt=3D'Gmail icon' width=3D\"49\" height=3D\"37\" src=3D\"https://ssl.gs=\r\ntatic.com/accounts/services/mail/msa/gmail_icon_large.png\"
+        style=3D\"display=\r\n:block;\"/></td><td style=3D\"align:left; font-family:'Open
+        sans','Arial',san=\r\ns-serif; vertical-align:bottom\"><span style=3D\"font-size:small\">Happy
+        email=\r\ning,<br/></span><span style=3D\"font-size:x-large; line-height:1\">The
+        Gmail =\r\nTeam</span></td></tr></table></div>\r\n</td></tr></table></div>\r\n<div
+        style=3D\"direction:ltr;color:#777; font-size:0.8em; border-radius:1em;=\r\n
+        padding:1em; margin:0 auto 4% auto; font-family:'Arial','Helvetica',sans-s=\r\nerif;
+        text-align:center;\">=C2=A9 2015 Google Inc. 1600 Amphitheatre Parkway=\r\n,
+        Mountain View, CA 94043<br/></div></div></body></html>\r\n\r\n--bcaec51dcff73ca5e9050ca9c59a--"
+  behavior: :return
+Net::IMAP-select-94dbf60c715b819f50691b23765fc8ff: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0006
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0006 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  behavior: :return
+Net::IMAP-uid_search-17072e68c206ea09b7a608dbc831d7c4: !ruby/object:Camcorder::Recording
+  value:
+  - 1
+  - 2
+  - 3
+  behavior: :return
+Net::IMAP-logout-2d909c15c1ac119141a370d89d276799: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0008
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0008 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/A_Gmail_mailbox/on_initialize/should_set_client_and_name.yml
+++ b/spec/recordings/A_Gmail_mailbox/on_initialize/should_set_client_and_name.yml
@@ -1,0 +1,20 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-logout-124c4cf9b43db611af2e6075d25b5b25: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/A_Gmail_mailbox/on_initialize/should_work_in_INBOX_by_default.yml
+++ b/spec/recordings/A_Gmail_mailbox/on_initialize/should_work_in_INBOX_by_default.yml
@@ -1,0 +1,20 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-logout-124c4cf9b43db611af2e6075d25b5b25: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Any_object/_new_should_connect_with_client_and_give_it_context_when_block_given.yml
+++ b/spec/recordings/Any_object/_new_should_connect_with_client_and_give_it_context_when_block_given.yml
@@ -1,0 +1,11 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Any_object/_new_should_not_raise_error_when_couldn_t_connect_with_given_account.yml
+++ b/spec/recordings/Any_object/_new_should_not_raise_error_when_couldn_t_connect_with_given_account.yml
@@ -1,0 +1,12 @@
+---
+Net::IMAP-login-bd531aecab77f9532e65b71cbc0b53b6: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials c77mb12013672oih
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials c77mb12013672oih
+      raw_data: "RUBY0001 NO Invalid credentials c77mb12013672oih\r\n"
+  behavior: :raise

--- a/spec/recordings/Any_object/_new_should_properly_connect_with_GMail_service_and_return_valid_connection_object.yml
+++ b/spec/recordings/Any_object/_new_should_properly_connect_with_GMail_service_and_return_valid_connection_object.yml
@@ -1,0 +1,11 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Any_object/_new_should_raise_error_when_couldn_t_connect_with_given_account.yml
+++ b/spec/recordings/Any_object/_new_should_raise_error_when_couldn_t_connect_with_given_account.yml
@@ -1,0 +1,12 @@
+---
+Net::IMAP-login-bd531aecab77f9532e65b71cbc0b53b6: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials zs9mb10361281oab
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials zs9mb10361281oab
+      raw_data: "RUBY0001 NO Invalid credentials zs9mb10361281oab\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/All/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/All/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,86 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-list-49ca2c937b3d5d1f57028f9e845b6642: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-logout-77aee31bb774480555c8a08e70c423c4: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Drafts/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Drafts/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,86 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-list-49ca2c937b3d5d1f57028f9e845b6642: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-logout-77aee31bb774480555c8a08e70c423c4: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Flagged/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Flagged/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,86 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-list-49ca2c937b3d5d1f57028f9e845b6642: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-logout-77aee31bb774480555c8a08e70c423c4: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Important/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Important/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,86 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-list-49ca2c937b3d5d1f57028f9e845b6642: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-logout-77aee31bb774480555c8a08e70c423c4: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Inbox/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Inbox/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,20 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-logout-124c4cf9b43db611af2e6075d25b5b25: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Junk/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Junk/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,86 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-list-49ca2c937b3d5d1f57028f9e845b6642: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-logout-77aee31bb774480555c8a08e70c423c4: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Sent/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Sent/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,86 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-list-49ca2c937b3d5d1f57028f9e845b6642: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-logout-77aee31bb774480555c8a08e70c423c4: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Trash/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/Gmail_Labels/_localize/when_given_the_XLIST_flag_/Trash/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,86 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-list-49ca2c937b3d5d1f57028f9e845b6642: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-logout-77aee31bb774480555c8a08e70c423c4: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
@@ -1,0 +1,158 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-list-9ef962ca1f2be408db1d7519f15edb72: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  behavior: :return
+Net::IMAP-list-0744e86d9f302f452ce5e0f782cbb175: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-list-f80cfbf62e2aa6a2854f65e51bd1450d: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  behavior: :return
+Net::IMAP-list-27296aa87f338bcba1d250999293c32c: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-logout-71ac9b826941f0e424ce7e9a5800f46e: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0006
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0006 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/labels/should_be_able_to_create_given_label.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/labels/should_be_able_to_create_given_label.yml
@@ -1,0 +1,125 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-create-2a7b885114e728ab12ba38a69a04da7d: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  behavior: :return
+Net::IMAP-list-9a5c11cb8c9f855780f1c7ddd0cfc23c: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: MYLABEL
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  behavior: :return
+Net::IMAP-list-c7a39834e54731a5dea661b9c5655619: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-create-a8b1225c26127012be49bf4e233137b2: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Duplicate folder name MYLABEL (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0005
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALREADYEXISTS
+          data: 
+        text: " Duplicate folder name MYLABEL (Failure)"
+      raw_data: "RUBY0005 NO [ALREADYEXISTS] Duplicate folder name MYLABEL (Failure)\r\n"
+  behavior: :raise
+Net::IMAP-delete-f3a45ee2553b8a0187a7e9b284e128f5: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0006
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0006 OK Success\r\n"
+  behavior: :return
+Net::IMAP-logout-338cbb8d4cb1ebc18b2246ccd5be67cd: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0007
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0007 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/labels/should_be_able_to_remove_existing_label.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/labels/should_be_able_to_remove_existing_label.yml
@@ -1,0 +1,120 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-create-2a7b885114e728ab12ba38a69a04da7d: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  behavior: :return
+Net::IMAP-delete-d42f8fca4cfba43664a54da78af853f4: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0003 OK Success\r\n"
+  behavior: :return
+Net::IMAP-list-d7f75362bf423f82118df2531a95d06e: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  behavior: :return
+Net::IMAP-list-aed85456696fae1d8506cebdc7273d3a: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-delete-c46fc76e27ed9b043b38ea590e21f357: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Unknown folder. (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0006
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: NONEXISTENT
+          data: 
+        text: " Unknown folder. (Failure)"
+      raw_data: "RUBY0006 NO [NONEXISTENT] Unknown folder. (Failure)\r\n"
+  behavior: :raise
+Net::IMAP-logout-057444b04b4829c06334adbe6f917ce9: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0007
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0007 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/labels/should_get_list_of_all_available_labels.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/labels/should_get_list_of_all_available_labels.yml
@@ -1,0 +1,89 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-list-9ef962ca1f2be408db1d7519f15edb72: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Awesome
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: Great
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    delim: "/"
+    name: INBOX
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Noselect
+    - :Haschildren
+    delim: "/"
+    name: "[Gmail]"
+  behavior: :return
+Net::IMAP-list-0744e86d9f302f452ce5e0f782cbb175: !ruby/object:Camcorder::Recording
+  value:
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :All
+    delim: "/"
+    name: "[Gmail]/All Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Drafts
+    delim: "/"
+    name: "[Gmail]/Drafts"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Important
+    delim: "/"
+    name: "[Gmail]/Important"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Sent
+    delim: "/"
+    name: "[Gmail]/Sent Mail"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Junk
+    delim: "/"
+    name: "[Gmail]/Spam"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Flagged
+    delim: "/"
+    name: "[Gmail]/Starred"
+  - !ruby/struct:Net::IMAP::MailboxList
+    attr:
+    - :Hasnochildren
+    - :Trash
+    delim: "/"
+    name: "[Gmail]/Trash"
+  behavior: :return
+Net::IMAP-logout-2b17a9ca833394fa6cc0faa492c31437: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0004
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0004 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/should_deliver_inline_composed_email.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/should_deliver_inline_composed_email.yml
@@ -1,0 +1,93 @@
+---
+Net::SMTP-enable_starttls_auto-edc274ea8a5cb035ede2a3b59ee5e4bf: !ruby/object:Camcorder::Recording
+  value: !ruby/object:OpenSSL::SSL::SSLContext
+    cert: 
+    key: 
+    client_ca: 
+    ca_file: 
+    ca_path: 
+    timeout: 
+    verify_mode: 
+    verify_depth: 
+    renegotiation_cb: 
+    verify_callback: 
+    options: 
+    cert_store: 
+    extra_chain_cert: 
+    client_cert_cb: 
+    tmp_dh_callback: 
+    session_id_context: 
+    session_get_cb: 
+    session_new_cb: 
+    session_remove_cb: 
+    servername_cb: 
+    npn_protocols: 
+    npn_select_cb: 
+  behavior: :return
+Net::SMTP-start-6b0dd4eb515e9d5c99efe9e150e07ddd: !ruby/object:Camcorder::Recording
+  value: !ruby/object:Net::SMTP
+    address: smtp.gmail.com
+    port: 587
+    esmtp: true
+    capabilities:
+      SIZE:
+      - '35882577'
+      8BITMIME: []
+      AUTH:
+      - LOGIN
+      - PLAIN
+      - XOAUTH
+      - XOAUTH2
+      - PLAIN-CLIENTTOKEN
+      ENHANCEDSTATUSCODES: []
+      PIPELINING: []
+      CHUNKING: []
+      SMTPUTF8: []
+    socket: !ruby/object:Net::InternetMessageIO
+      io: !ruby/object:OpenSSL::SSL::SSLSocket
+        io: !ruby/object:TCPSocket {}
+        context: &1 !ruby/object:OpenSSL::SSL::SSLContext
+          cert: 
+          key: 
+          client_ca: 
+          ca_file: 
+          ca_path: 
+          timeout: 
+          verify_mode: 
+          verify_depth: 
+          renegotiation_cb: 
+          verify_callback: 
+          options: 
+          cert_store: 
+          extra_chain_cert: 
+          client_cert_cb: 
+          tmp_dh_callback: 
+          session_id_context: 
+          session_get_cb: 
+          session_new_cb: 
+          session_remove_cb: 
+          servername_cb: 
+          npn_protocols: 
+          npn_select_cb: 
+        sync_close: true
+        hostname: 
+        eof: false
+        rbuffer: ''
+        sync: true
+        callback_state: 
+        wbuffer: ''
+      read_timeout: 60
+      continue_timeout: 
+      debug_output: 
+      rbuf: ''
+      wbuf: 
+      written_bytes: 
+    started: true
+    open_timeout: 30
+    read_timeout: 60
+    error_occurred: false
+    debug_output: 
+    tls: false
+    starttls: :auto
+    ssl_context: *1
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/should_properly_login_to_valid_GMail_account.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/should_properly_login_to_valid_GMail_account.yml
@@ -1,0 +1,20 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-logout-124c4cf9b43db611af2e6075d25b5b25: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/should_properly_logout_from_GMail.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/should_properly_logout_from_GMail.yml
@@ -1,0 +1,20 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-logout-124c4cf9b43db611af2e6075d25b5b25: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/should_properly_switch_to_given_mailbox.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/should_properly_switch_to_given_mailbox.yml
@@ -1,0 +1,31 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-select-952b2929efa40a77889483d7484c90ea: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0002 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  behavior: :return
+Net::IMAP-logout-ebf2631e2b49b74eebce3c3295b80560: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
@@ -1,0 +1,31 @@
+---
+Net::IMAP-login-758fd0590883627b674b8a18ed2eaa88: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  behavior: :return
+Net::IMAP-select-952b2929efa40a77889483d7484c90ea: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0002 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  behavior: :return
+Net::IMAP-logout-ebf2631e2b49b74eebce3c3295b80560: !ruby/object:Camcorder::Recording
+  value: !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  behavior: :return

--- a/spec/recordings/Gmail_client_Plain_/instance/should_raise_error_when_given_GMail_account_is_invalid_and_errors_enabled.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/should_raise_error_when_given_GMail_account_is_invalid_and_errors_enabled.yml
@@ -1,0 +1,12 @@
+---
+Net::IMAP-login-bd531aecab77f9532e65b71cbc0b53b6: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials dn4mb10462074oab
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials dn4mb10462074oab
+      raw_data: "RUBY0001 NO Invalid credentials dn4mb10462074oab\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_Plain_/instance/shouldn_t_login_when_given_GMail_account_is_invalid.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/shouldn_t_login_when_given_GMail_account_is_invalid.yml
@@ -1,0 +1,12 @@
+---
+Net::IMAP-login-bd531aecab77f9532e65b71cbc0b53b6: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials q5mb8656235obq
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials q5mb8656235obq
+      raw_data: "RUBY0001 NO Invalid credentials q5mb8656235obq\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_Plain_/instance/shouldn_t_raise_error_even_though_GMail_account_is_invalid.yml
+++ b/spec/recordings/Gmail_client_Plain_/instance/shouldn_t_raise_error_even_though_GMail_account_is_invalid.yml
@@ -1,0 +1,12 @@
+---
+Net::IMAP-login-bd531aecab77f9532e65b71cbc0b53b6: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials x5mb12284505oix
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials x5mb12284505oix
+      raw_data: "RUBY0001 NO Invalid credentials x5mb12284505oix\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
@@ -1,0 +1,14 @@
+---
+Net::IMAP-authenticate-3034f36a0762e890775aa0490f495ced: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/labels/should_be_able_to_create_given_label.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/labels/should_be_able_to_create_given_label.yml
@@ -1,0 +1,14 @@
+---
+Net::IMAP-authenticate-3034f36a0762e890775aa0490f495ced: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/labels/should_be_able_to_remove_existing_label.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/labels/should_be_able_to_remove_existing_label.yml
@@ -1,0 +1,14 @@
+---
+Net::IMAP-authenticate-3034f36a0762e890775aa0490f495ced: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/labels/should_get_list_of_all_available_labels.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/labels/should_get_list_of_all_available_labels.yml
@@ -1,0 +1,14 @@
+---
+Net::IMAP-authenticate-3034f36a0762e890775aa0490f495ced: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/should_deliver_inline_composed_email.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/should_deliver_inline_composed_email.yml
@@ -1,0 +1,31 @@
+---
+Net::SMTP-enable_starttls_auto-edc274ea8a5cb035ede2a3b59ee5e4bf: !ruby/object:Camcorder::Recording
+  value: !ruby/object:OpenSSL::SSL::SSLContext
+    cert: 
+    key: 
+    client_ca: 
+    ca_file: 
+    ca_path: 
+    timeout: 
+    verify_mode: 
+    verify_depth: 
+    renegotiation_cb: 
+    verify_callback: 
+    options: 
+    cert_store: 
+    extra_chain_cert: 
+    client_cert_cb: 
+    tmp_dh_callback: 
+    session_id_context: 
+    session_get_cb: 
+    session_new_cb: 
+    session_remove_cb: 
+    servername_cb: 
+    npn_protocols: 
+    npn_select_cb: 
+  behavior: :return
+Net::SMTP-start-2fdfd8fe575d2997d9bb0de1de58e8a6: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::SMTPAuthenticationError
+    message: |
+      334 eyJzdGF0dXMiOiI0MDAiLCJzY2hlbWVzIjoiQmVhcmVyIiwic2NvcGUiOiJodHRwczovL21haWwuZ29vZ2xlLmNvbS8ifQ==
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/should_properly_login_to_valid_GMail_account.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/should_properly_login_to_valid_GMail_account.yml
@@ -1,0 +1,14 @@
+---
+Net::IMAP-authenticate-3034f36a0762e890775aa0490f495ced: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/should_properly_logout_from_GMail.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/should_properly_logout_from_GMail.yml
@@ -1,0 +1,14 @@
+---
+Net::IMAP-authenticate-3034f36a0762e890775aa0490f495ced: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/should_properly_switch_to_given_mailbox.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/should_properly_switch_to_given_mailbox.yml
@@ -1,0 +1,14 @@
+---
+Net::IMAP-authenticate-3034f36a0762e890775aa0490f495ced: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
@@ -1,0 +1,14 @@
+---
+Net::IMAP-authenticate-3034f36a0762e890775aa0490f495ced: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/should_raise_error_when_given_GMail_account_is_invalid_and_errors_enabled.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/should_raise_error_when_given_GMail_account_is_invalid_and_errors_enabled.yml
@@ -1,0 +1,12 @@
+---
+Net::IMAP-authenticate-49090e02fa025950f6b79d7cf67dfe62: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials zt10mb10255731oab
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials zt10mb10255731oab
+      raw_data: "RUBY0001 NO Invalid credentials zt10mb10255731oab\r\n"
+  behavior: :raise

--- a/spec/recordings/Gmail_client_XOAuth2_/instance/shouldn_t_login_when_given_GMail_account_is_invalid.yml
+++ b/spec/recordings/Gmail_client_XOAuth2_/instance/shouldn_t_login_when_given_GMail_account_is_invalid.yml
@@ -1,0 +1,12 @@
+---
+Net::IMAP-authenticate-49090e02fa025950f6b79d7cf67dfe62: !ruby/object:Camcorder::Recording
+  value: !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials q5mb8657154obq
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials q5mb8657154obq
+      raw_data: "RUBY0001 NO Invalid credentials q5mb8657154obq\r\n"
+  behavior: :raise

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,19 @@ require 'rubygems'
 require 'rspec'
 require 'yaml'
 require 'gmail'
+require 'camcorder'
+require 'camcorder/rspec'
+
+Camcorder.config.recordings_dir = 'spec/recordings'
 
 RSpec.configure do |config|
+  config.before(:suite) do
+    Camcorder.intercept_constructor(Net::IMAP) do
+      methods_with_side_effects :login, :logout, :list, :examine, :select, :create, :delete
+    end
+
+    Camcorder.intercept_constructor(Net::SMTP)
+  end
 end
 
 def within_gmail(&block)
@@ -15,7 +26,7 @@ def within_gmail(&block)
   gmail.logout if gmail
 end
 
-def mock_client(&block) 
+def mock_client(&block)
   client = Gmail::Client::Plain.new(*TEST_ACCOUNT)
   if block_given?
     client.connect


### PR DESCRIPTION
Fixes #103

Webmock and VCR are only for HTTP so they won't be useful here. Camcorder is a gem that can be used to record and replay arbitrary method calls on a given object. This includes basic configuration for mocking IMAP and SMTP and all the recordings for the existing specs.