### PR TITLE
Mock Net::IMAP calls

### DIFF
--- a/spec/recordings/a_gmail_mailbox/instance/should_be_able_to_count_all_emails.yml
+++ b/spec/recordings/a_gmail_mailbox/instance/should_be_able_to_count_all_emails.yml
@@ -67,25 +67,25 @@ SELECT-505f013d922af4caf157dc91d6b45a60:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 69
+        data: 83
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '7631'
+        data: '8312'
       text: ''
     PERMANENTFLAGS: &4
     - *1
     UIDVALIDITY: &5
     - 1
     EXISTS: &6
-    - 68
+    - 82
     RECENT: &7
     - 0
     UIDNEXT: &8
-    - 69
+    - 83
     HIGHESTMODSEQ: &9
-    - '7631'
+    - '8312'
 UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -172,6 +172,20 @@ UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
       - 66
       - 67
       - 68
+      - 69
+      - 70
+      - 71
+      - 72
+      - 73
+      - 74
+      - 75
+      - 76
+      - 77
+      - 78
+      - 79
+      - 80
+      - 81
+      - 82
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse

--- a/spec/recordings/a_gmail_mailbox/instance/should_be_able_to_count_all_emails.yml
+++ b/spec/recordings/a_gmail_mailbox/instance/should_be_able_to_count_all_emails.yml
@@ -1,0 +1,195 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY:
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+SELECT-505f013d922af4caf157dc91d6b45a60:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0002 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  - FLAGS: &2
+    - - :Answered
+      - :Flagged
+      - :Draft
+      - :Deleted
+      - :Seen
+      - "$Phishing"
+      - "$NotPhishing"
+    OK: &3
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: PERMANENTFLAGS
+        data: &1
+        - :Answered
+        - :Flagged
+        - :Draft
+        - :Deleted
+        - :Seen
+        - "$Phishing"
+        - "$NotPhishing"
+        - :*
+      text: " Flags permitted."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDVALIDITY
+        data: 1
+      text: " UIDs valid."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDNEXT
+        data: 69
+      text: " Predicted next UID."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: HIGHESTMODSEQ
+        data: '7631'
+      text: ''
+    PERMANENTFLAGS: &4
+    - *1
+    UIDVALIDITY: &5
+    - 1
+    EXISTS: &6
+    - 68
+    RECENT: &7
+    - 0
+    UIDNEXT: &8
+    - 69
+    HIGHESTMODSEQ: &9
+    - '7631'
+UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: SEARCH completed (Success)
+    raw_data: "RUBY0003 OK SEARCH completed (Success)\r\n"
+  - FLAGS: *2
+    OK: *3
+    PERMANENTFLAGS: *4
+    UIDVALIDITY: *5
+    EXISTS: *6
+    RECENT: *7
+    UIDNEXT: *8
+    HIGHESTMODSEQ: *9
+    SEARCH:
+    - - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+      - 17
+      - 18
+      - 19
+      - 20
+      - 21
+      - 22
+      - 23
+      - 24
+      - 25
+      - 26
+      - 27
+      - 28
+      - 29
+      - 30
+      - 31
+      - 32
+      - 33
+      - 34
+      - 35
+      - 36
+      - 37
+      - 38
+      - 39
+      - 40
+      - 41
+      - 42
+      - 43
+      - 44
+      - 45
+      - 46
+      - 47
+      - 48
+      - 49
+      - 50
+      - 51
+      - 52
+      - 53
+      - 54
+      - 55
+      - 56
+      - 57
+      - 58
+      - 59
+      - 60
+      - 61
+      - 62
+      - 63
+      - 64
+      - 65
+      - 66
+      - 67
+      - 68
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0004
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0004 OK 73 good day (Success)\r\n"
+  - FLAGS: *2
+    OK: *3
+    PERMANENTFLAGS: *4
+    UIDVALIDITY: *5
+    EXISTS: *6
+    RECENT: *7
+    UIDNEXT: *8
+    HIGHESTMODSEQ: *9
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/a_gmail_mailbox/instance/should_be_able_to_find_messages.yml
+++ b/spec/recordings/a_gmail_mailbox/instance/should_be_able_to_find_messages.yml
@@ -1,0 +1,472 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY:
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+SELECT-505f013d922af4caf157dc91d6b45a60:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0002 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  - FLAGS: &4
+    - - :Answered
+      - :Flagged
+      - :Draft
+      - :Deleted
+      - :Seen
+      - "$Phishing"
+      - "$NotPhishing"
+    OK: &5
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: PERMANENTFLAGS
+        data: &1
+        - :Answered
+        - :Flagged
+        - :Draft
+        - :Deleted
+        - :Seen
+        - "$Phishing"
+        - "$NotPhishing"
+        - :*
+      text: " Flags permitted."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDVALIDITY
+        data: 1
+      text: " UIDs valid."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDNEXT
+        data: 69
+      text: " Predicted next UID."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: HIGHESTMODSEQ
+        data: '7631'
+      text: ''
+    PERMANENTFLAGS: &6
+    - *1
+    UIDVALIDITY: &7
+    - 1
+    EXISTS: &8
+    - 68
+    RECENT: &9
+    - 0
+    UIDNEXT: &10
+    - 69
+    HIGHESTMODSEQ: &11
+    - '7631'
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0004
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0004 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  - FLAGS: &12
+    - - :Answered
+      - :Flagged
+      - :Draft
+      - :Deleted
+      - :Seen
+      - "$Phishing"
+      - "$NotPhishing"
+    OK: &13
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: PERMANENTFLAGS
+        data: &2
+        - :Answered
+        - :Flagged
+        - :Draft
+        - :Deleted
+        - :Seen
+        - "$Phishing"
+        - "$NotPhishing"
+        - :*
+      text: " Flags permitted."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDVALIDITY
+        data: 1
+      text: " UIDs valid."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDNEXT
+        data: 69
+      text: " Predicted next UID."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: HIGHESTMODSEQ
+        data: '7631'
+      text: ''
+    PERMANENTFLAGS: &14
+    - *2
+    UIDVALIDITY: &15
+    - 1
+    EXISTS: &16
+    - 68
+    RECENT: &17
+    - 0
+    UIDNEXT: &18
+    - 69
+    HIGHESTMODSEQ: &19
+    - '7631'
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0006
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0006 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  - FLAGS: &20
+    - - :Answered
+      - :Flagged
+      - :Draft
+      - :Deleted
+      - :Seen
+      - "$Phishing"
+      - "$NotPhishing"
+    OK: &21
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: PERMANENTFLAGS
+        data: &3
+        - :Answered
+        - :Flagged
+        - :Draft
+        - :Deleted
+        - :Seen
+        - "$Phishing"
+        - "$NotPhishing"
+        - :*
+      text: " Flags permitted."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDVALIDITY
+        data: 1
+      text: " UIDs valid."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDNEXT
+        data: 69
+      text: " Predicted next UID."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: HIGHESTMODSEQ
+        data: '7631'
+      text: ''
+    PERMANENTFLAGS: &22
+    - *3
+    UIDVALIDITY: &23
+    - 1
+    EXISTS: &24
+    - 68
+    RECENT: &25
+    - 0
+    UIDNEXT: &26
+    - 69
+    HIGHESTMODSEQ: &27
+    - '7631'
+UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: SEARCH completed (Success)
+    raw_data: "RUBY0003 OK SEARCH completed (Success)\r\n"
+  - FLAGS: *4
+    OK: *5
+    PERMANENTFLAGS: *6
+    UIDVALIDITY: *7
+    EXISTS: *8
+    RECENT: *9
+    UIDNEXT: *10
+    HIGHESTMODSEQ: *11
+    SEARCH:
+    - - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+      - 17
+      - 18
+      - 19
+      - 20
+      - 21
+      - 22
+      - 23
+      - 24
+      - 25
+      - 26
+      - 27
+      - 28
+      - 29
+      - 30
+      - 31
+      - 32
+      - 33
+      - 34
+      - 35
+      - 36
+      - 37
+      - 38
+      - 39
+      - 40
+      - 41
+      - 42
+      - 43
+      - 44
+      - 45
+      - 46
+      - 47
+      - 48
+      - 49
+      - 50
+      - 51
+      - 52
+      - 53
+      - 54
+      - 55
+      - 56
+      - 57
+      - 58
+      - 59
+      - 60
+      - 61
+      - 62
+      - 63
+      - 64
+      - 65
+      - 66
+      - 67
+      - 68
+UID FETCH-2acc41ab9b9f9af181ba9994387f13a9:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0005
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0005 OK Success\r\n"
+  - FLAGS: *12
+    OK: *13
+    PERMANENTFLAGS: *14
+    UIDVALIDITY: *15
+    EXISTS: *16
+    RECENT: *17
+    UIDNEXT: *18
+    HIGHESTMODSEQ: *19
+    FETCH:
+    - !ruby/struct:Net::IMAP::FetchData
+      seqno: 1
+      attr:
+        X-GM-MSGID: 1490339162618061913
+        X-GM-LABELS: []
+        UID: 1
+        FLAGS:
+        - :Seen
+        ENVELOPE: !ruby/struct:Net::IMAP::Envelope
+          date: Wed, 14 Jan 2015 21:03:01 -0800
+          subject: Three tips to get the most out of Gmail
+          from:
+          - !ruby/struct:Net::IMAP::Address
+            name: Gmail Team
+            route: 
+            mailbox: mail-noreply
+            host: google.com
+          sender:
+          - !ruby/struct:Net::IMAP::Address
+            name: Gmail Team
+            route: 
+            mailbox: mail-noreply
+            host: google.com
+          reply_to:
+          - !ruby/struct:Net::IMAP::Address
+            name: Gmail Team
+            route: 
+            mailbox: mail-noreply
+            host: google.com
+          to:
+          - !ruby/struct:Net::IMAP::Address
+            name: John Doe
+            route: 
+            mailbox: ki0zvkyi1yzgy7xu4f4dh46nqrcecm
+            host: gmail.com
+          cc: 
+          bcc: 
+          in_reply_to: 
+          message_id: "<CACNRAYKakHOCaxin=3D-9QAC=GRQgDae66vLpwqPQC6rDAJK2w@mail.gmail.com>"
+        BODY[]: "MIME-Version: 1.0\r\nx-no-auto-attachment: 1\r\nReceived: by 10.70.87.10;
+          Wed, 14 Jan 2015 21:03:01 -0800 (PST)\r\nDate: Wed, 14 Jan 2015 21:03:01
+          -0800\r\nMessage-ID: <CACNRAYKakHOCaxin=3D-9QAC=GRQgDae66vLpwqPQC6rDAJK2w@mail.gmail.com>\r\nSubject:
+          Three tips to get the most out of Gmail\r\nFrom: Gmail Team <mail-noreply@google.com>\r\nTo:
+          John Doe <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nContent-Type: multipart/alternative;
+          boundary=bcaec51dcff73ca5e9050ca9c59a\r\n\r\n--bcaec51dcff73ca5e9050ca9c59a\r\nContent-Type:
+          text/plain; charset=UTF-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n
+          Three tips to get the most out of Gmail\r\n[image: Google]\r\n\r\nHi John\r\n\r\nTips
+          to get the most out of Gmail\r\n\r\n[image: Contacts]\r\nBring your contacts
+          and mail into Gmail\r\n\r\nOn your computer, you can copy your contacts
+          and emails from your old email\r\naccount to make the transition to Gmail
+          even better. Learn how\r\n<https://support.google.com/mail/answer/164640?hl=3Den&ref_topic=3D1669014>=\r\n.\r\n[image:
+          Search]\r\nFind what you need fast\r\n\r\nWith the power of Google Search
+          right in your inbox, it's easy to sort your\r\nemail. Find what you're looking
+          for with predictions based on email\r\ncontent, past searches and contacts.\r\n[image:
+          Search]\r\nMuch more than email\r\n\r\nYou can send text messages and make
+          video calls with Hangouts\r\n<https://www.google.com/intl/en/hangouts/>
+          right from Gmail. To use this\r\nfeature on mobile, download the Hangouts
+          app for Android\r\n<https://play.google.com/store/apps/details?id=3Dcom.google.android.talk&hl=\r\n=3Den>\r\nand
+          Apple <https://itunes.apple.com/en/app/hangouts/id643496868?mt=3D8>\r\ndevices.\r\n\r\n\r\n[image:
+          Gmail icon]Happy emailing,\r\nThe Gmail Team\r\n =C2=A9 2015 Google Inc.
+          1600 Amphitheatre Parkway, Mountain View, CA 94043\r\n\r\n--bcaec51dcff73ca5e9050ca9c59a\r\nContent-Type:
+          text/html; charset=UTF-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n<!DOCTYPE
+          html>\r\n<html><head><meta http-equiv=3D\"content-type\" content=3D\"text/html;charset=\r\n=3DUTF-8\"
+          /><title>Three tips to get the most out of Gmail</title></head><b=\r\nody
+          style=3D\"background-color:#e5e5e5; margin:20px 0;\"><br /><div style=3D\"=\r\nmargin:2%;\"><div
+          style=3D\"direction:ltr; text-align:left; font-family:'Open=\r\n sans','Arial',sans-serif;
+          color:#444; background-color:white; padding:1.5e=\r\nm; border-radius:1em;
+          box-shadow:1px -5px 8px 2px #bbb; max-width:580px; ma=\r\nrgin:2% auto 0
+          auto;\"><table style=3D\"background:white;width:100%\"><tr><td>=\r\n<div
+          style=3D\"width:90px; height:54px; margin:10px auto;\"><img src=3D\"https=\r\n://services.google.com/fh/files/emails/google_logo_flat_90_color.png\"
+          alt=\r\n=3D\"Google\" width=3D\"90\" height=3D\"34\"/></div><div style=3D\"width:90%;
+          padd=\r\ning-bottom:10px; padding-left:15px\"><p><img alt=3D\"\" src=3D\"https://ssl.gst=\r\natic.com/accounts/services/mail/msa/gmail_icon_small.png\"
+          style=3D\"display:=\r\nblock; float:left; margin-top:4px; margin-right:5px;\"/><span
+          style=3D\"font-=\r\nfamily:'Open sans','Arial',sans-serif; font-weight:bold;
+          font-size:small; l=\r\nine-height:1.4em\">Hi John</span></p><p><span style=3D\"font-family:'Open
+          san=\r\ns','Arial',sans-serif; font-size:2.08em;\">Tips to get the most
+          out of Gmail=\r\n</span><br/></p></div><p></p><div style=3D\"float:left;
+          clear:both; padding:=\r\n0px 5px 10px 10px;\"><img src=3D\"https://services.google.com/fh/files/emails=\r\n/importcontacts.png\"
+          alt=3D\"Contacts\" style=3D\"display:block;\"width=3D\"129\"=\r\nheight=3D\"129\"/></div><div
+          style=3D\"float:left; vertical-align:middle; padd=\r\ning:10px; max-width:398px;
+          float:left;\"><table style=3D\"vertical-align:midd=\r\nle;\"><tr><td style=3D\"font-family:'Open
+          sans','Arial',sans-serif;\"><span st=\r\nyle=3D\"font-size:20px;\">Bring
+          your contacts and mail into Gmail</span><br/>=\r\n<br/><span style=3D\"font-size:small;
+          line-height:1.4em\">On your computer, y=\r\nou can copy your contacts and
+          emails from your old email account to make th=\r\ne transition to Gmail
+          even better. <a href=3D\"https://support.google.com/ma=\r\nil/answer/164640?hl=3Den&amp;ref_topic=3D1669014\"
+          style=3D\"text-decoration:=\r\nnone; color:#15C\">Learn how</a>.</span></td></tr></table></div><div
+          style=\r\n=3D\"float:left; clear:both; padding:0px 5px 10px 10px;\"><img
+          src=3D\"https:/=\r\n/ssl.gstatic.com/mail/welcome/localized/en/welcome_search.png\"
+          alt=3D\"Searc=\r\nh\" style=3D\"display:block;\"width=3D\"129\"height=3D\"129\"/></div><div
+          style=3D=\r\n\"float:left; vertical-align:middle; padding:10px; max-width:398px;
+          float:le=\r\nft;\"><table style=3D\"vertical-align:middle;\"><tr><td style=3D\"font-family:'=\r\nOpen
+          sans','Arial',sans-serif;\"><span style=3D\"font-size:20px;\">Find what
+          y=\r\nou need fast</span><br/><br/><span style=3D\"font-size:small; line-height:1.=\r\n4em\">With
+          the power of Google Search right in your inbox, it's easy to sort=\r\n your
+          email. Find what you're looking for with predictions based on email c=\r\nontent,
+          past searches and contacts.</span></td></tr></table></div><div styl=\r\ne=3D\"float:left;
+          clear:both; padding:0px 5px 10px 10px;\"><img src=3D\"https:=\r\n//ssl.gstatic.com/accounts/services/mail/msa/welcome_hangouts.png\"
+          alt=3D\"S=\r\nearch\" style=3D\"display:block;\"width=3D\"129\"height=3D\"129\"/></div><div
+          styl=\r\ne=3D\"float:left; vertical-align:middle; padding:10px; max-width:398px;
+          floa=\r\nt:left;\"><table style=3D\"vertical-align:middle;\"><tr><td style=3D\"font-fami=\r\nly:'Open
+          sans','Arial',sans-serif;\"><span style=3D\"font-size:20px;\">Much mo=\r\nre
+          than email</span><br/><br/><span style=3D\"font-size:small; line-height:1=\r\n.4em\">You
+          can send text messages and make video calls with <a href=3D\"https=\r\n://www.google.com/intl/en/hangouts/\"
+          style=3D\"text-decoration:none; color:#=\r\n15C\">Hangouts</a> right from
+          Gmail. To use this feature on mobile, download=\r\n the Hangouts app for
+          <a href=3D\"https://play.google.com/store/apps/details=\r\n?id=3Dcom.google.android.talk&amp;hl=3Den\"
+          style=3D\"text-decoration:none; c=\r\nolor:#15C\">Android</a> and <a href=3D\"https://itunes.apple.com/en/app/hango=\r\nuts/id643496868?mt=3D8\"
+          style=3D\"text-decoration:none; color:#15C\">Apple</a=\r\n> devices.</span></td></tr></table></div><br/><br/>\r\n<div
+          style=3D\"clear:both; padding-left:13px; height:6.8em;\"><table style=3D=\r\n\"width:100%;
+          border-collapse:collapse; border:0\"><tr><td style=3D\"width:68p=\r\nx\"><img
+          alt=3D'Gmail icon' width=3D\"49\" height=3D\"37\" src=3D\"https://ssl.gs=\r\ntatic.com/accounts/services/mail/msa/gmail_icon_large.png\"
+          style=3D\"display=\r\n:block;\"/></td><td style=3D\"align:left; font-family:'Open
+          sans','Arial',san=\r\ns-serif; vertical-align:bottom\"><span style=3D\"font-size:small\">Happy
+          email=\r\ning,<br/></span><span style=3D\"font-size:x-large; line-height:1\">The
+          Gmail =\r\nTeam</span></td></tr></table></div>\r\n</td></tr></table></div>\r\n<div
+          style=3D\"direction:ltr;color:#777; font-size:0.8em; border-radius:1em;=\r\n
+          padding:1em; margin:0 auto 4% auto; font-family:'Arial','Helvetica',sans-s=\r\nerif;
+          text-align:center;\">=C2=A9 2015 Google Inc. 1600 Amphitheatre Parkway=\r\n,
+          Mountain View, CA 94043<br/></div></div></body></html>\r\n\r\n--bcaec51dcff73ca5e9050ca9c59a--"
+UID SEARCH-543c4aa0876fcec438e0bdc20193d4bb:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0007
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: SEARCH completed (Success)
+    raw_data: "RUBY0007 OK SEARCH completed (Success)\r\n"
+  - FLAGS: *20
+    OK: *21
+    PERMANENTFLAGS: *22
+    UIDVALIDITY: *23
+    EXISTS: *24
+    RECENT: *25
+    UIDNEXT: *26
+    HIGHESTMODSEQ: *27
+    SEARCH:
+    - - 1
+      - 2
+      - 3
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0008
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0008 OK 73 good day (Success)\r\n"
+  - FLAGS: *20
+    OK: *21
+    PERMANENTFLAGS: *22
+    UIDVALIDITY: *23
+    EXISTS: *24
+    RECENT: *25
+    UIDNEXT: *26
+    HIGHESTMODSEQ: *27
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/a_gmail_mailbox/instance/should_be_able_to_find_messages.yml
+++ b/spec/recordings/a_gmail_mailbox/instance/should_be_able_to_find_messages.yml
@@ -67,25 +67,25 @@ SELECT-505f013d922af4caf157dc91d6b45a60:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 69
+        data: 83
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '7631'
+        data: '8312'
       text: ''
     PERMANENTFLAGS: &6
     - *1
     UIDVALIDITY: &7
     - 1
     EXISTS: &8
-    - 68
+    - 82
     RECENT: &9
     - 0
     UIDNEXT: &10
-    - 69
+    - 83
     HIGHESTMODSEQ: &11
-    - '7631'
+    - '8312'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0004
@@ -126,25 +126,25 @@ SELECT-505f013d922af4caf157dc91d6b45a60:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 69
+        data: 83
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '7631'
+        data: '8312'
       text: ''
     PERMANENTFLAGS: &14
     - *2
     UIDVALIDITY: &15
     - 1
     EXISTS: &16
-    - 68
+    - 82
     RECENT: &17
     - 0
     UIDNEXT: &18
-    - 69
+    - 83
     HIGHESTMODSEQ: &19
-    - '7631'
+    - '8312'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0006
@@ -185,25 +185,25 @@ SELECT-505f013d922af4caf157dc91d6b45a60:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 69
+        data: 83
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '7631'
+        data: '8312'
       text: ''
     PERMANENTFLAGS: &22
     - *3
     UIDVALIDITY: &23
     - 1
     EXISTS: &24
-    - 68
+    - 82
     RECENT: &25
     - 0
     UIDNEXT: &26
-    - 69
+    - 83
     HIGHESTMODSEQ: &27
-    - '7631'
+    - '8312'
 UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -290,6 +290,20 @@ UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
       - 66
       - 67
       - 68
+      - 69
+      - 70
+      - 71
+      - 72
+      - 73
+      - 74
+      - 75
+      - 76
+      - 77
+      - 78
+      - 79
+      - 80
+      - 81
+      - 82
 UID FETCH-2acc41ab9b9f9af181ba9994387f13a9:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse

--- a/spec/recordings/a_gmail_mailbox/on_initialize/should_set_client_and_name.yml
+++ b/spec/recordings/a_gmail_mailbox/on_initialize/should_set_client_and_name.yml
@@ -1,0 +1,42 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/a_gmail_mailbox/on_initialize/should_work_in_inbox_by_default.yml
+++ b/spec/recordings/a_gmail_mailbox/on_initialize/should_work_in_inbox_by_default.yml
@@ -1,0 +1,42 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/any_object/_new_should_connect_with_client_and_give_it_context_when_block_given.yml
+++ b/spec/recordings/any_object/_new_should_connect_with_client_and_give_it_context_when_block_given.yml
@@ -1,0 +1,28 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY:
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT

--- a/spec/recordings/any_object/_new_should_not_raise_error_when_couldn_t_connect_with_given_account.yml
+++ b/spec/recordings/any_object/_new_should_not_raise_error_when_couldn_t_connect_with_given_account.yml
@@ -2,12 +2,12 @@
 LOGIN-f0cde728d1c78eb72490f79825821b1c:
 - - :raise
   - !ruby/exception:Net::IMAP::NoResponseError
-    message: Invalid credentials bf8mb13513317oac
+    message: Invalid credentials e5mb14145422oah
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0001
       name: 'NO'
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Invalid credentials bf8mb13513317oac
-      raw_data: "RUBY0001 NO Invalid credentials bf8mb13513317oac\r\n"
+        text: Invalid credentials e5mb14145422oah
+      raw_data: "RUBY0001 NO Invalid credentials e5mb14145422oah\r\n"
   - {}

--- a/spec/recordings/any_object/_new_should_not_raise_error_when_couldn_t_connect_with_given_account.yml
+++ b/spec/recordings/any_object/_new_should_not_raise_error_when_couldn_t_connect_with_given_account.yml
@@ -1,0 +1,13 @@
+---
+LOGIN-f0cde728d1c78eb72490f79825821b1c:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials bf8mb13513317oac
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials bf8mb13513317oac
+      raw_data: "RUBY0001 NO Invalid credentials bf8mb13513317oac\r\n"
+  - {}

--- a/spec/recordings/any_object/_new_should_properly_connect_with_gmail_service_and_return_valid_connection_object.yml
+++ b/spec/recordings/any_object/_new_should_properly_connect_with_gmail_service_and_return_valid_connection_object.yml
@@ -1,0 +1,28 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY:
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT

--- a/spec/recordings/any_object/_new_should_raise_error_when_couldn_t_connect_with_given_account.yml
+++ b/spec/recordings/any_object/_new_should_raise_error_when_couldn_t_connect_with_given_account.yml
@@ -1,0 +1,13 @@
+---
+LOGIN-f0cde728d1c78eb72490f79825821b1c:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials y125mb2524500oiy
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials y125mb2524500oiy
+      raw_data: "RUBY0001 NO Invalid credentials y125mb2524500oiy\r\n"
+  - {}

--- a/spec/recordings/any_object/_new_should_raise_error_when_couldn_t_connect_with_given_account.yml
+++ b/spec/recordings/any_object/_new_should_raise_error_when_couldn_t_connect_with_given_account.yml
@@ -2,12 +2,12 @@
 LOGIN-f0cde728d1c78eb72490f79825821b1c:
 - - :raise
   - !ruby/exception:Net::IMAP::NoResponseError
-    message: Invalid credentials y125mb2524500oiy
+    message: Invalid credentials ld5mb12086173obb
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0001
       name: 'NO'
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Invalid credentials y125mb2524500oiy
-      raw_data: "RUBY0001 NO Invalid credentials y125mb2524500oiy\r\n"
+        text: Invalid credentials ld5mb12086173obb
+      raw_data: "RUBY0001 NO Invalid credentials ld5mb12086173obb\r\n"
   - {}

--- a/spec/recordings/gmail_client_plain/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
+++ b/spec/recordings/gmail_client_plain/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
@@ -1,0 +1,196 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LIST-e0583fa6130ee374cef031c01d8cc486:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0004
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0004 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+LIST-94cc1ce946087e61b81baed886d31dbc:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0003 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0005
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0005 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"

--- a/spec/recordings/gmail_client_plain/instance/labels/should_be_able_to_create_given_label.yml
+++ b/spec/recordings/gmail_client_plain/instance/labels/should_be_able_to_create_given_label.yml
@@ -1,0 +1,151 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+CREATE-873546102acc7776d52edef1516784eb:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Duplicate folder name MYLABEL (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0005
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALREADYEXISTS
+          data: 
+        text: " Duplicate folder name MYLABEL (Failure)"
+      raw_data: "RUBY0005 NO [ALREADYEXISTS] Duplicate folder name MYLABEL (Failure)\r\n"
+  - CAPABILITY: *1
+LIST-e0583fa6130ee374cef031c01d8cc486:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0003 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: MYLABEL
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+LIST-94cc1ce946087e61b81baed886d31dbc:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0004
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0004 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"
+DELETE-842c8f8a15eef1d47151d7a37868de75:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0006
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0006 OK Success\r\n"
+  - CAPABILITY: *1

--- a/spec/recordings/gmail_client_plain/instance/labels/should_be_able_to_remove_existing_label.yml
+++ b/spec/recordings/gmail_client_plain/instance/labels/should_be_able_to_remove_existing_label.yml
@@ -1,0 +1,146 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+CREATE-873546102acc7776d52edef1516784eb:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+DELETE-842c8f8a15eef1d47151d7a37868de75:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0003 OK Success\r\n"
+  - CAPABILITY: *1
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Unknown folder. (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0006
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: NONEXISTENT
+          data: 
+        text: " Unknown folder. (Failure)"
+      raw_data: "RUBY0006 NO [NONEXISTENT] Unknown folder. (Failure)\r\n"
+  - CAPABILITY: *1
+LIST-e0583fa6130ee374cef031c01d8cc486:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0004
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0004 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+LIST-94cc1ce946087e61b81baed886d31dbc:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0005
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0005 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"

--- a/spec/recordings/gmail_client_plain/instance/labels/should_get_list_of_all_available_labels.yml
+++ b/spec/recordings/gmail_client_plain/instance/labels/should_get_list_of_all_available_labels.yml
@@ -1,0 +1,113 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LIST-e0583fa6130ee374cef031c01d8cc486:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+LIST-94cc1ce946087e61b81baed886d31dbc:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0003 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"

--- a/spec/recordings/gmail_client_plain/instance/should_properly_login_to_valid_gmail_account.yml
+++ b/spec/recordings/gmail_client_plain/instance/should_properly_login_to_valid_gmail_account.yml
@@ -1,0 +1,42 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_client_plain/instance/should_properly_logout_from_gmail.yml
+++ b/spec/recordings/gmail_client_plain/instance/should_properly_logout_from_gmail.yml
@@ -1,0 +1,42 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_client_plain/instance/should_properly_switch_to_given_mailbox.yml
+++ b/spec/recordings/gmail_client_plain/instance/should_properly_switch_to_given_mailbox.yml
@@ -1,0 +1,109 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY:
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+SELECT-505f013d922af4caf157dc91d6b45a60:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0002 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  - FLAGS: &2
+    - - :Answered
+      - :Flagged
+      - :Draft
+      - :Deleted
+      - :Seen
+      - "$Phishing"
+      - "$NotPhishing"
+    OK: &3
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: PERMANENTFLAGS
+        data: &1
+        - :Answered
+        - :Flagged
+        - :Draft
+        - :Deleted
+        - :Seen
+        - "$Phishing"
+        - "$NotPhishing"
+        - :*
+      text: " Flags permitted."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDVALIDITY
+        data: 1
+      text: " UIDs valid."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDNEXT
+        data: 69
+      text: " Predicted next UID."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: HIGHESTMODSEQ
+        data: '7553'
+      text: ''
+    PERMANENTFLAGS: &4
+    - *1
+    UIDVALIDITY: &5
+    - 1
+    EXISTS: &6
+    - 68
+    RECENT: &7
+    - 0
+    UIDNEXT: &8
+    - 69
+    HIGHESTMODSEQ: &9
+    - '7553'
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  - FLAGS: *2
+    OK: *3
+    PERMANENTFLAGS: *4
+    UIDVALIDITY: *5
+    EXISTS: *6
+    RECENT: *7
+    UIDNEXT: *8
+    HIGHESTMODSEQ: *9
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_client_plain/instance/should_properly_switch_to_given_mailbox.yml
+++ b/spec/recordings/gmail_client_plain/instance/should_properly_switch_to_given_mailbox.yml
@@ -67,25 +67,25 @@ SELECT-505f013d922af4caf157dc91d6b45a60:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 69
+        data: 83
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '7553'
+        data: '8244'
       text: ''
     PERMANENTFLAGS: &4
     - *1
     UIDVALIDITY: &5
     - 1
     EXISTS: &6
-    - 68
+    - 82
     RECENT: &7
     - 0
     UIDNEXT: &8
-    - 69
+    - 83
     HIGHESTMODSEQ: &9
-    - '7553'
+    - '8244'
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse

--- a/spec/recordings/gmail_client_plain/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
+++ b/spec/recordings/gmail_client_plain/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
@@ -1,0 +1,109 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY:
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+SELECT-505f013d922af4caf157dc91d6b45a60:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: READ-WRITE
+        data: 
+      text: " INBOX selected. (Success)"
+    raw_data: "RUBY0002 OK [READ-WRITE] INBOX selected. (Success)\r\n"
+  - FLAGS: &2
+    - - :Answered
+      - :Flagged
+      - :Draft
+      - :Deleted
+      - :Seen
+      - "$Phishing"
+      - "$NotPhishing"
+    OK: &3
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: PERMANENTFLAGS
+        data: &1
+        - :Answered
+        - :Flagged
+        - :Draft
+        - :Deleted
+        - :Seen
+        - "$Phishing"
+        - "$NotPhishing"
+        - :*
+      text: " Flags permitted."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDVALIDITY
+        data: 1
+      text: " UIDs valid."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: UIDNEXT
+        data: 69
+      text: " Predicted next UID."
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: !ruby/struct:Net::IMAP::ResponseCode
+        name: HIGHESTMODSEQ
+        data: '7553'
+      text: ''
+    PERMANENTFLAGS: &4
+    - *1
+    UIDVALIDITY: &5
+    - 1
+    EXISTS: &6
+    - 68
+    RECENT: &7
+    - 0
+    UIDNEXT: &8
+    - 69
+    HIGHESTMODSEQ: &9
+    - '7553'
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  - FLAGS: *2
+    OK: *3
+    PERMANENTFLAGS: *4
+    UIDVALIDITY: *5
+    EXISTS: *6
+    RECENT: *7
+    UIDNEXT: *8
+    HIGHESTMODSEQ: *9
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_client_plain/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
+++ b/spec/recordings/gmail_client_plain/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
@@ -67,25 +67,25 @@ SELECT-505f013d922af4caf157dc91d6b45a60:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 69
+        data: 83
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '7553'
+        data: '8244'
       text: ''
     PERMANENTFLAGS: &4
     - *1
     UIDVALIDITY: &5
     - 1
     EXISTS: &6
-    - 68
+    - 82
     RECENT: &7
     - 0
     UIDNEXT: &8
-    - 69
+    - 83
     HIGHESTMODSEQ: &9
-    - '7553'
+    - '8244'
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse

--- a/spec/recordings/gmail_client_plain/instance/should_raise_error_when_given_gmail_account_is_invalid_and_errors_enabled.yml
+++ b/spec/recordings/gmail_client_plain/instance/should_raise_error_when_given_gmail_account_is_invalid_and_errors_enabled.yml
@@ -2,12 +2,12 @@
 LOGIN-f0cde728d1c78eb72490f79825821b1c:
 - - :raise
   - !ruby/exception:Net::IMAP::NoResponseError
-    message: Invalid credentials q5mb11839283obq
+    message: Invalid credentials zz5mb13772187oab
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0001
       name: 'NO'
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Invalid credentials q5mb11839283obq
-      raw_data: "RUBY0001 NO Invalid credentials q5mb11839283obq\r\n"
+        text: Invalid credentials zz5mb13772187oab
+      raw_data: "RUBY0001 NO Invalid credentials zz5mb13772187oab\r\n"
   - {}

--- a/spec/recordings/gmail_client_plain/instance/should_raise_error_when_given_gmail_account_is_invalid_and_errors_enabled.yml
+++ b/spec/recordings/gmail_client_plain/instance/should_raise_error_when_given_gmail_account_is_invalid_and_errors_enabled.yml
@@ -1,0 +1,13 @@
+---
+LOGIN-f0cde728d1c78eb72490f79825821b1c:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials q5mb11839283obq
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials q5mb11839283obq
+      raw_data: "RUBY0001 NO Invalid credentials q5mb11839283obq\r\n"
+  - {}

--- a/spec/recordings/gmail_client_plain/instance/shouldn_t_login_when_given_gmail_account_is_invalid.yml
+++ b/spec/recordings/gmail_client_plain/instance/shouldn_t_login_when_given_gmail_account_is_invalid.yml
@@ -1,0 +1,13 @@
+---
+LOGIN-f0cde728d1c78eb72490f79825821b1c:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials h205mb15460717oia
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials h205mb15460717oia
+      raw_data: "RUBY0001 NO Invalid credentials h205mb15460717oia\r\n"
+  - {}

--- a/spec/recordings/gmail_client_plain/instance/shouldn_t_login_when_given_gmail_account_is_invalid.yml
+++ b/spec/recordings/gmail_client_plain/instance/shouldn_t_login_when_given_gmail_account_is_invalid.yml
@@ -2,12 +2,12 @@
 LOGIN-f0cde728d1c78eb72490f79825821b1c:
 - - :raise
   - !ruby/exception:Net::IMAP::NoResponseError
-    message: Invalid credentials h205mb15460717oia
+    message: Invalid credentials vz12mb11973448obc
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0001
       name: 'NO'
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Invalid credentials h205mb15460717oia
-      raw_data: "RUBY0001 NO Invalid credentials h205mb15460717oia\r\n"
+        text: Invalid credentials vz12mb11973448obc
+      raw_data: "RUBY0001 NO Invalid credentials vz12mb11973448obc\r\n"
   - {}

--- a/spec/recordings/gmail_client_plain/instance/shouldn_t_raise_error_even_though_gmail_account_is_invalid.yml
+++ b/spec/recordings/gmail_client_plain/instance/shouldn_t_raise_error_even_though_gmail_account_is_invalid.yml
@@ -1,0 +1,13 @@
+---
+LOGIN-f0cde728d1c78eb72490f79825821b1c:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials bp14mb13420318oec
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials bp14mb13420318oec
+      raw_data: "RUBY0001 NO Invalid credentials bp14mb13420318oec\r\n"
+  - {}

--- a/spec/recordings/gmail_client_plain/instance/shouldn_t_raise_error_even_though_gmail_account_is_invalid.yml
+++ b/spec/recordings/gmail_client_plain/instance/shouldn_t_raise_error_even_though_gmail_account_is_invalid.yml
@@ -2,12 +2,12 @@
 LOGIN-f0cde728d1c78eb72490f79825821b1c:
 - - :raise
   - !ruby/exception:Net::IMAP::NoResponseError
-    message: Invalid credentials bp14mb13420318oec
+    message: Invalid credentials xx2mb12249277obc
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0001
       name: 'NO'
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Invalid credentials bp14mb13420318oec
-      raw_data: "RUBY0001 NO Invalid credentials bp14mb13420318oec\r\n"
+        text: Invalid credentials xx2mb12249277obc
+      raw_data: "RUBY0001 NO Invalid credentials xx2mb12249277obc\r\n"
   - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
@@ -1,0 +1,27 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}
+LIST-e0583fa6130ee374cef031c01d8cc486:
+- - :raise
+  - !ruby/exception:Net::IMAP::BadResponseError
+    message: Unknown command jf5mb13464136oeb
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0002
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Unknown command jf5mb13464136oeb
+      raw_data: "RUBY0002 BAD Unknown command jf5mb13464136oeb\r\n"
+  - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_check_if_there_is_given_label_defined.yml
@@ -16,12 +16,12 @@ AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
 LIST-e0583fa6130ee374cef031c01d8cc486:
 - - :raise
   - !ruby/exception:Net::IMAP::BadResponseError
-    message: Unknown command jf5mb13464136oeb
+    message: Unknown command tn2mb13373457oec
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0002
       name: BAD
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Unknown command jf5mb13464136oeb
-      raw_data: "RUBY0002 BAD Unknown command jf5mb13464136oeb\r\n"
+        text: Unknown command tn2mb13373457oec
+      raw_data: "RUBY0002 BAD Unknown command tn2mb13373457oec\r\n"
   - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_create_given_label.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_create_given_label.yml
@@ -16,24 +16,24 @@ AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
 CREATE-873546102acc7776d52edef1516784eb:
 - - :raise
   - !ruby/exception:Net::IMAP::BadResponseError
-    message: Unknown command zz5mb13504299oab
+    message: Unknown command c131mb15695345oig
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0002
       name: BAD
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Unknown command zz5mb13504299oab
-      raw_data: "RUBY0002 BAD Unknown command zz5mb13504299oab\r\n"
+        text: Unknown command c131mb15695345oig
+      raw_data: "RUBY0002 BAD Unknown command c131mb15695345oig\r\n"
   - {}
 LIST-e0583fa6130ee374cef031c01d8cc486:
 - - :raise
   - !ruby/exception:Net::IMAP::BadResponseError
-    message: Unknown command zz5mb13504299oab
+    message: Unknown command c131mb15695345oig
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0003
       name: BAD
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Unknown command zz5mb13504299oab
-      raw_data: "RUBY0003 BAD Unknown command zz5mb13504299oab\r\n"
+        text: Unknown command c131mb15695345oig
+      raw_data: "RUBY0003 BAD Unknown command c131mb15695345oig\r\n"
   - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_create_given_label.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_create_given_label.yml
@@ -1,0 +1,39 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}
+CREATE-873546102acc7776d52edef1516784eb:
+- - :raise
+  - !ruby/exception:Net::IMAP::BadResponseError
+    message: Unknown command zz5mb13504299oab
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0002
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Unknown command zz5mb13504299oab
+      raw_data: "RUBY0002 BAD Unknown command zz5mb13504299oab\r\n"
+  - {}
+LIST-e0583fa6130ee374cef031c01d8cc486:
+- - :raise
+  - !ruby/exception:Net::IMAP::BadResponseError
+    message: Unknown command zz5mb13504299oab
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0003
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Unknown command zz5mb13504299oab
+      raw_data: "RUBY0003 BAD Unknown command zz5mb13504299oab\r\n"
+  - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_remove_existing_label.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_remove_existing_label.yml
@@ -1,0 +1,39 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}
+CREATE-873546102acc7776d52edef1516784eb:
+- - :raise
+  - !ruby/exception:Net::IMAP::BadResponseError
+    message: Unknown command ij14mb13799860oab
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0002
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Unknown command ij14mb13799860oab
+      raw_data: "RUBY0002 BAD Unknown command ij14mb13799860oab\r\n"
+  - {}
+DELETE-842c8f8a15eef1d47151d7a37868de75:
+- - :raise
+  - !ruby/exception:Net::IMAP::BadResponseError
+    message: Unknown command ij14mb13799860oab
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0003
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Unknown command ij14mb13799860oab
+      raw_data: "RUBY0003 BAD Unknown command ij14mb13799860oab\r\n"
+  - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_remove_existing_label.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/labels/should_be_able_to_remove_existing_label.yml
@@ -16,24 +16,24 @@ AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
 CREATE-873546102acc7776d52edef1516784eb:
 - - :raise
   - !ruby/exception:Net::IMAP::BadResponseError
-    message: Unknown command ij14mb13799860oab
+    message: Unknown command bp14mb13691893oec
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0002
       name: BAD
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Unknown command ij14mb13799860oab
-      raw_data: "RUBY0002 BAD Unknown command ij14mb13799860oab\r\n"
+        text: Unknown command bp14mb13691893oec
+      raw_data: "RUBY0002 BAD Unknown command bp14mb13691893oec\r\n"
   - {}
 DELETE-842c8f8a15eef1d47151d7a37868de75:
 - - :raise
   - !ruby/exception:Net::IMAP::BadResponseError
-    message: Unknown command ij14mb13799860oab
+    message: Unknown command bp14mb13691893oec
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0003
       name: BAD
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Unknown command ij14mb13799860oab
-      raw_data: "RUBY0003 BAD Unknown command ij14mb13799860oab\r\n"
+        text: Unknown command bp14mb13691893oec
+      raw_data: "RUBY0003 BAD Unknown command bp14mb13691893oec\r\n"
   - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/labels/should_get_list_of_all_available_labels.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/labels/should_get_list_of_all_available_labels.yml
@@ -1,0 +1,27 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}
+LIST-e0583fa6130ee374cef031c01d8cc486:
+- - :raise
+  - !ruby/exception:Net::IMAP::BadResponseError
+    message: Unknown command o1mb13464977oem
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0002
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Unknown command o1mb13464977oem
+      raw_data: "RUBY0002 BAD Unknown command o1mb13464977oem\r\n"
+  - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/labels/should_get_list_of_all_available_labels.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/labels/should_get_list_of_all_available_labels.yml
@@ -16,12 +16,12 @@ AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
 LIST-e0583fa6130ee374cef031c01d8cc486:
 - - :raise
   - !ruby/exception:Net::IMAP::BadResponseError
-    message: Unknown command o1mb13464977oem
+    message: Unknown command be1mb13873281oac
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0002
       name: BAD
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Unknown command o1mb13464977oem
-      raw_data: "RUBY0002 BAD Unknown command o1mb13464977oem\r\n"
+        text: Unknown command be1mb13873281oac
+      raw_data: "RUBY0002 BAD Unknown command be1mb13873281oac\r\n"
   - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/should_properly_login_to_valid_gmail_account.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/should_properly_login_to_valid_gmail_account.yml
@@ -1,0 +1,15 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/should_properly_logout_from_gmail.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/should_properly_logout_from_gmail.yml
@@ -1,0 +1,15 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/should_properly_switch_to_given_mailbox.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/should_properly_switch_to_given_mailbox.yml
@@ -29,12 +29,12 @@ AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
 SELECT-23d55e3c8382681ca67adbbab76993a1:
 - - :raise
   - !ruby/exception:Net::IMAP::BadResponseError
-    message: Unknown command a23mb15751169oib
+    message: Unknown command w200mb5798766oia
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0003
       name: BAD
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Unknown command a23mb15751169oib
-      raw_data: "RUBY0003 BAD Unknown command a23mb15751169oib\r\n"
+        text: Unknown command w200mb5798766oia
+      raw_data: "RUBY0003 BAD Unknown command w200mb5798766oia\r\n"
   - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/should_properly_switch_to_given_mailbox.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/should_properly_switch_to_given_mailbox.yml
@@ -1,0 +1,40 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0002
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0002 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}
+SELECT-23d55e3c8382681ca67adbbab76993a1:
+- - :raise
+  - !ruby/exception:Net::IMAP::BadResponseError
+    message: Unknown command a23mb15751169oib
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0003
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Unknown command a23mb15751169oib
+      raw_data: "RUBY0003 BAD Unknown command a23mb15751169oib\r\n"
+  - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
@@ -1,0 +1,40 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0001 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: " Invalid credentials (Failure)"
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0002
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: !ruby/struct:Net::IMAP::ResponseCode
+          name: ALERT
+          data: 
+        text: " Invalid credentials (Failure)"
+      raw_data: "RUBY0002 NO [ALERT] Invalid credentials (Failure)\r\n"
+  - {}
+SELECT-23d55e3c8382681ca67adbbab76993a1:
+- - :raise
+  - !ruby/exception:Net::IMAP::BadResponseError
+    message: Unknown command y125mb2523533oiy
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0003
+      name: BAD
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Unknown command y125mb2523533oiy
+      raw_data: "RUBY0003 BAD Unknown command y125mb2523533oiy\r\n"
+  - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/should_properly_switch_to_given_mailbox_using_block_style.yml
@@ -29,12 +29,12 @@ AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
 SELECT-23d55e3c8382681ca67adbbab76993a1:
 - - :raise
   - !ruby/exception:Net::IMAP::BadResponseError
-    message: Unknown command y125mb2523533oiy
+    message: Unknown command t5mb12207606obi
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0003
       name: BAD
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Unknown command y125mb2523533oiy
-      raw_data: "RUBY0003 BAD Unknown command y125mb2523533oiy\r\n"
+        text: Unknown command t5mb12207606obi
+      raw_data: "RUBY0003 BAD Unknown command t5mb12207606obi\r\n"
   - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/should_raise_error_when_given_gmail_account_is_invalid_and_errors_enabled.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/should_raise_error_when_given_gmail_account_is_invalid_and_errors_enabled.yml
@@ -2,12 +2,12 @@
 AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
 - - :raise
   - !ruby/exception:Net::IMAP::NoResponseError
-    message: Invalid credentials b10mb11689951obn
+    message: Invalid credentials j6mb13583769oeh
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0001
       name: 'NO'
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Invalid credentials b10mb11689951obn
-      raw_data: "RUBY0001 NO Invalid credentials b10mb11689951obn\r\n"
+        text: Invalid credentials j6mb13583769oeh
+      raw_data: "RUBY0001 NO Invalid credentials j6mb13583769oeh\r\n"
   - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/should_raise_error_when_given_gmail_account_is_invalid_and_errors_enabled.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/should_raise_error_when_given_gmail_account_is_invalid_and_errors_enabled.yml
@@ -1,0 +1,13 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials b10mb11689951obn
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials b10mb11689951obn
+      raw_data: "RUBY0001 NO Invalid credentials b10mb11689951obn\r\n"
+  - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/shouldn_t_login_when_given_gmail_account_is_invalid.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/shouldn_t_login_when_given_gmail_account_is_invalid.yml
@@ -2,12 +2,12 @@
 AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
 - - :raise
   - !ruby/exception:Net::IMAP::NoResponseError
-    message: Invalid credentials y130mb5733682oia
+    message: Invalid credentials or17mb13406678oeb
     response: !ruby/struct:Net::IMAP::TaggedResponse
       tag: RUBY0001
       name: 'NO'
       data: !ruby/struct:Net::IMAP::ResponseText
         code: 
-        text: Invalid credentials y130mb5733682oia
-      raw_data: "RUBY0001 NO Invalid credentials y130mb5733682oia\r\n"
+        text: Invalid credentials or17mb13406678oeb
+      raw_data: "RUBY0001 NO Invalid credentials or17mb13406678oeb\r\n"
   - {}

--- a/spec/recordings/gmail_client_xo_auth2/instance/shouldn_t_login_when_given_gmail_account_is_invalid.yml
+++ b/spec/recordings/gmail_client_xo_auth2/instance/shouldn_t_login_when_given_gmail_account_is_invalid.yml
@@ -1,0 +1,13 @@
+---
+AUTHENTICATE-48cc3379658326e2b0e5cd2a6f3da2af:
+- - :raise
+  - !ruby/exception:Net::IMAP::NoResponseError
+    message: Invalid credentials y130mb5733682oia
+    response: !ruby/struct:Net::IMAP::TaggedResponse
+      tag: RUBY0001
+      name: 'NO'
+      data: !ruby/struct:Net::IMAP::ResponseText
+        code: 
+        text: Invalid credentials y130mb5733682oia
+      raw_data: "RUBY0001 NO Invalid credentials y130mb5733682oia\r\n"
+  - {}

--- a/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/all/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/all/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,116 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LIST-b30698c3407aff5520448484b159fc07:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/drafts/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/drafts/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,116 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LIST-b30698c3407aff5520448484b159fc07:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/flagged/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/flagged/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,116 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LIST-b30698c3407aff5520448484b159fc07:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/important/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/important/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,116 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LIST-b30698c3407aff5520448484b159fc07:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/inbox/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/inbox/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,42 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0002 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/junk/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/junk/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,116 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LIST-b30698c3407aff5520448484b159fc07:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/sent/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/sent/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,116 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LIST-b30698c3407aff5520448484b159fc07:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested

--- a/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/trash/localizes_into_the_appropriate_label.yml
+++ b/spec/recordings/gmail_labels/localize/when_given_the_xl_is_tflag/trash/localizes_into_the_appropriate_label.yml
@@ -1,0 +1,116 @@
+---
+LOGIN-9a890af1c86854f5170d99be6e10b8f1:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0001
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated (Success)
+    raw_data: "RUBY0001 OK ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com authenticated
+      (Success)\r\n"
+  - CAPABILITY: &1
+    - - IMAP4REV1
+      - UNSELECT
+      - IDLE
+      - NAMESPACE
+      - QUOTA
+      - ID
+      - XLIST
+      - CHILDREN
+      - X-GM-EXT-1
+      - UIDPLUS
+      - COMPRESS=DEFLATE
+      - ENABLE
+      - MOVE
+      - CONDSTORE
+      - ESEARCH
+      - UTF8=ACCEPT
+LIST-b30698c3407aff5520448484b159fc07:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0002
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: Success
+    raw_data: "RUBY0002 OK Success\r\n"
+  - CAPABILITY: *1
+    LIST:
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Awesome
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: Great
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      delim: "/"
+      name: INBOX
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Noselect
+      - :Haschildren
+      delim: "/"
+      name: "[Gmail]"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :All
+      delim: "/"
+      name: "[Gmail]/All Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Drafts
+      delim: "/"
+      name: "[Gmail]/Drafts"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Important
+      delim: "/"
+      name: "[Gmail]/Important"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Sent
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Sent Mail"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Junk
+      delim: "/"
+      name: "[Gmail]/Spam"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Hasnochildren
+      - :Flagged
+      delim: "/"
+      name: "[Gmail]/Starred"
+    - !ruby/struct:Net::IMAP::MailboxList
+      attr:
+      - :Trash
+      - :Hasnochildren
+      delim: "/"
+      name: "[Gmail]/Trash"
+LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
+- - :return
+  - !ruby/struct:Net::IMAP::TaggedResponse
+    tag: RUBY0003
+    name: OK
+    data: !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: 73 good day (Success)
+    raw_data: "RUBY0003 OK 73 good day (Success)\r\n"
+  - CAPABILITY: *1
+    BYE:
+    - !ruby/struct:Net::IMAP::ResponseText
+      code: 
+      text: LOGOUT Requested


### PR DESCRIPTION
Fixes #103

This is another attempt at mocking calls to Google in order to remove the dependency on hitting the remote service during tests (necessary for the CI server). The initial attempt used the `Camcorder` gem, which didn't really give enough granular control and ran into trouble when mocking method calls across differing Ruby versions.

This uses the same idea as Camcorder - recording responses from actual requests to Google. However it just stubs out the `Net::IMAP#send_command` method and replays recorded responses if they exist. Otherwise, it will record the response to be used next.