### PR TITLE
Add thread id to Gmail::Message

### DIFF
--- a/lib/gmail/message.rb
+++ b/lib/gmail/message.rb
@@ -1,11 +1,9 @@
 module Gmail
   class Message
-    PREFETCH_ATTRS = ["UID", "ENVELOPE", "BODY.PEEK[]", "FLAGS", "X-GM-LABELS", "X-GM-MSGID"]
+    PREFETCH_ATTRS = ["UID", "ENVELOPE", "BODY.PEEK[]", "FLAGS", "X-GM-LABELS", "X-GM-MSGID", "X-GM-THRID"]
 
     # Raised when given label doesn't exists.
     class NoLabelError < Exception; end
-
-    attr_reader :uid, :envelope, :message, :flags, :labels
 
     def initialize(mailbox, uid, _attrs = nil)
       @uid     = uid
@@ -21,6 +19,12 @@ module Gmail
     def msg_id
       @msg_id ||= fetch("X-GM-MSGID")
     end
+    alias_method :message_id, :msg_id
+
+    def thr_id
+      @thr_id ||= fetch("X-GM-THRID")
+    end
+    alias_method :thread_id, :thr_id
 
     def envelope
       @envelope ||= fetch("ENVELOPE")
@@ -155,7 +159,7 @@ module Gmail
     alias_method :remove_label!, :remove_label
 
     def inspect
-      "#<Gmail::Message#{'0x%04x' % (object_id << 1)} mailbox=#{@mailbox.name}#{' uid=' + @uid.to_s if @uid}#{' message_id=' + @message_id.to_s if @message_id}>"
+      "#<Gmail::Message#{'0x%04x' % (object_id << 1)} mailbox=#{@mailbox.name}#{' uid=' + @uid.to_s if @uid}#{' message_id=' + @msg_id.to_s if @msg_id}>"
     end
 
     def method_missing(meth, *args, &block)
@@ -184,6 +188,7 @@ module Gmail
     def clear_cached_attributes
       @_attrs   = nil
       @msg_id   = nil
+      @thr_id   = nil
       @envelope = nil
       @message  = nil
       @flags    = nil

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -15,6 +15,16 @@ describe Gmail::Message do
       subject.instance_variable_get(:@uid).should be_a Integer
       subject.labels
     end
+
+    it "should set PREFETCH_ATTRS" do
+      subject.uid.should be_a Integer
+      subject.msg_id.should be_a Integer
+      subject.thr_id.should be_a Integer
+      subject.envelope.should be_a Net::IMAP::Envelope
+      subject.message.should be_a Mail::Message
+      subject.flags.should be_a Array
+      subject.labels.should be_a Array
+    end
   end
 
   describe "mocks" do

--- a/spec/recordings/gmail_mailbox/instance/should_be_able_to_find_messages.yml
+++ b/spec/recordings/gmail_mailbox/instance/should_be_able_to_find_messages.yml
@@ -67,25 +67,25 @@ SELECT-505f013d922af4caf157dc91d6b45a60:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 159
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13352'
+        data: '14699'
       text: ''
     PERMANENTFLAGS: &6
     - *1
     UIDVALIDITY: &7
     - 1
     EXISTS: &8
-    - 150
+    - 181
     RECENT: &9
     - 0
     UIDNEXT: &10
-    - 159
+    - 190
     HIGHESTMODSEQ: &11
-    - '13352'
+    - '14699'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0004
@@ -126,25 +126,25 @@ SELECT-505f013d922af4caf157dc91d6b45a60:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 159
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13352'
+        data: '14699'
       text: ''
     PERMANENTFLAGS: &14
     - *2
     UIDVALIDITY: &15
     - 1
     EXISTS: &16
-    - 150
+    - 181
     RECENT: &17
     - 0
     UIDNEXT: &18
-    - 159
+    - 190
     HIGHESTMODSEQ: &19
-    - '13352'
+    - '14699'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0006
@@ -185,25 +185,25 @@ SELECT-505f013d922af4caf157dc91d6b45a60:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 159
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13352'
+        data: '14699'
       text: ''
     PERMANENTFLAGS: &22
     - *3
     UIDVALIDITY: &23
     - 1
     EXISTS: &24
-    - 150
+    - 181
     RECENT: &25
     - 0
     UIDNEXT: &26
-    - 159
+    - 190
     HIGHESTMODSEQ: &27
-    - '13352'
+    - '14699'
 UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -372,7 +372,38 @@ UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
       - 156
       - 157
       - 158
-UID FETCH-2acc41ab9b9f9af181ba9994387f13a9:
+      - 159
+      - 160
+      - 161
+      - 162
+      - 163
+      - 164
+      - 165
+      - 166
+      - 167
+      - 168
+      - 169
+      - 170
+      - 171
+      - 172
+      - 173
+      - 174
+      - 175
+      - 176
+      - 177
+      - 178
+      - 179
+      - 180
+      - 181
+      - 182
+      - 183
+      - 184
+      - 185
+      - 186
+      - 187
+      - 188
+      - 189
+UID FETCH-70e92ae4507a5481cf98aac122edceb8:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0005
@@ -393,6 +424,7 @@ UID FETCH-2acc41ab9b9f9af181ba9994387f13a9:
     - !ruby/struct:Net::IMAP::FetchData
       seqno: 1
       attr:
+        X-GM-THRID: 1490339162618061913
         X-GM-MSGID: 1490339162618061913
         X-GM-LABELS: []
         UID: 1

--- a/spec/recordings/gmail_message/initialize/should_set_prefetch_attrs.yml
+++ b/spec/recordings/gmail_message/initialize/should_set_prefetch_attrs.yml
@@ -161,25 +161,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 190
+        data: 187
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '14699'
+        data: '14589'
       text: ''
     PERMANENTFLAGS: &6
     - *2
     UIDVALIDITY: &7
     - 11
     EXISTS: &8
-    - 181
+    - 179
     RECENT: &9
     - 0
     UIDNEXT: &10
-    - 190
+    - 187
     HIGHESTMODSEQ: &11
-    - '14699'
+    - '14589'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0005
@@ -220,25 +220,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 190
+        data: 187
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '14699'
+        data: '14589'
       text: ''
     PERMANENTFLAGS: &14
     - *3
     UIDVALIDITY: &15
     - 11
     EXISTS: &16
-    - 181
+    - 179
     RECENT: &17
     - 0
     UIDNEXT: &18
-    - 190
+    - 187
     HIGHESTMODSEQ: &19
-    - '14699'
+    - '14589'
 UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -436,8 +436,6 @@ UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
       - 184
       - 185
       - 186
-      - 188
-      - 189
 UID FETCH-70e92ae4507a5481cf98aac122edceb8:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse

--- a/spec/recordings/gmail_message/instance_methods/should_allow_moving_from_one_tag_to_other.yml
+++ b/spec/recordings/gmail_message/instance_methods/should_allow_moving_from_one_tag_to_other.yml
@@ -161,25 +161,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13217'
+        data: '14734'
       text: ''
     PERMANENTFLAGS: &10
     - *2
     UIDVALIDITY: &11
     - 11
     EXISTS: &12
-    - 150
+    - 181
     RECENT: &13
     - 0
     UIDNEXT: &14
-    - 157
+    - 190
     HIGHESTMODSEQ: &15
-    - '13217'
+    - '14734'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0005
@@ -220,25 +220,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13217'
+        data: '14734'
       text: ''
     PERMANENTFLAGS: &18
     - *3
     UIDVALIDITY: &19
     - 11
     EXISTS: &20
-    - 150
+    - 181
     RECENT: &21
     - 0
     UIDNEXT: &22
-    - 157
+    - 190
     HIGHESTMODSEQ: &23
-    - '13217'
+    - '14734'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0007
@@ -279,25 +279,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13224'
+        data: '14741'
       text: ''
     PERMANENTFLAGS: &26
     - *4
     UIDVALIDITY: &27
     - 11
     EXISTS: &28
-    - 150
+    - 181
     RECENT: &29
     - 0
     UIDNEXT: &30
-    - 157
+    - 190
     HIGHESTMODSEQ: &31
-    - '13224'
+    - '14741'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0009
@@ -338,25 +338,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13231'
+        data: '14748'
       text: ''
     PERMANENTFLAGS: &34
     - *5
     UIDVALIDITY: &35
     - 11
     EXISTS: &36
-    - 150
+    - 181
     RECENT: &37
     - 0
     UIDNEXT: &38
-    - 157
+    - 190
     HIGHESTMODSEQ: &39
-    - '13231'
+    - '14748'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0011
@@ -397,25 +397,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13238'
+        data: '14755'
       text: ''
     PERMANENTFLAGS: &42
     - *6
     UIDVALIDITY: &43
     - 11
     EXISTS: &44
-    - 150
+    - 181
     RECENT: &45
     - 0
     UIDNEXT: &46
-    - 157
+    - 190
     HIGHESTMODSEQ: &47
-    - '13238'
+    - '14755'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0013
@@ -456,25 +456,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13245'
+        data: '14762'
       text: ''
     PERMANENTFLAGS: &50
     - *7
     UIDVALIDITY: &51
     - 11
     EXISTS: &52
-    - 150
+    - 181
     RECENT: &53
     - 0
     UIDNEXT: &54
-    - 157
+    - 190
     HIGHESTMODSEQ: &55
-    - '13245'
+    - '14762'
 UID SEARCH-0010f3078427015fc193bf14c1871582:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -630,9 +630,35 @@ UID SEARCH-0010f3078427015fc193bf14c1871582:
       - 143
       - 144
       - 145
-      - 146
-      - 156
-UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
+      - 157
+      - 158
+      - 159
+      - 160
+      - 161
+      - 162
+      - 166
+      - 167
+      - 168
+      - 169
+      - 170
+      - 171
+      - 172
+      - 173
+      - 174
+      - 175
+      - 176
+      - 177
+      - 178
+      - 179
+      - 180
+      - 181
+      - 182
+      - 183
+      - 184
+      - 185
+      - 188
+      - 189
+UID STORE-ac884ffbfb66da354d64b0f2d42a166f:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0006
@@ -651,7 +677,7 @@ UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
     HIGHESTMODSEQ: *23
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
@@ -659,8 +685,8 @@ UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
-UID STORE-3a1222c7da7c0bb8d03304910c31ca2d:
+        UID: 189
+UID STORE-e1d9a7c253865f43e2e1170eb52cfcec:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0008
@@ -679,15 +705,15 @@ UID STORE-3a1222c7da7c0bb8d03304910c31ca2d:
     HIGHESTMODSEQ: *31
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Awesome
-        UID: 156
-UID STORE-643ffd7492792039322aa146f528ae70:
+        UID: 189
+UID STORE-c2d6f8de722e6c9f06f0a6a1a4163f69:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0010
@@ -706,7 +732,7 @@ UID STORE-643ffd7492792039322aa146f528ae70:
     HIGHESTMODSEQ: *39
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
@@ -714,8 +740,8 @@ UID STORE-643ffd7492792039322aa146f528ae70:
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
-UID STORE-3183f490549e85f11879b2f1e2e7cdce:
+        UID: 189
+UID STORE-2e46c35991051e7831af457bc2435903:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0012
@@ -734,15 +760,15 @@ UID STORE-3183f490549e85f11879b2f1e2e7cdce:
     HIGHESTMODSEQ: *47
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Great
-        UID: 156
-UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
+        UID: 189
+UID FETCH-c91d19726aebc8362537324efef9b96b:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0014
@@ -761,18 +787,19 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
     HIGHESTMODSEQ: *55
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
-        X-GM-MSGID: 1490757948419620310
+        X-GM-THRID: 1490771293684090059
+        X-GM-MSGID: 1490771293684090059
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Great
-        UID: 156
+        UID: 189
         FLAGS: []
         ENVELOPE: !ruby/struct:Net::IMAP::Envelope
-          date: Mon, 19 Jan 2015 14:59:25 -0500
+          date: Mon, 19 Jan 2015 18:31:32 -0500
           subject: Hello world!
           from:
           - !ruby/struct:Net::IMAP::Address
@@ -801,15 +828,15 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
           cc: 
           bcc: 
           in_reply_to: 
-          message_id: "<54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>"
+          message_id: "<54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>"
         BODY[]: "Return-Path: <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nReceived:
           from gmail.com (99-156-120-246.lightspeed.miamfl.sbcglobal.net. [99.156.120.246])\r\n
-          \       by mx.google.com with ESMTPSA id nt5sm6321261obb.26.2015.01.19.11.59.26\r\n
+          \       by mx.google.com with ESMTPSA id a15sm890292oic.18.2015.01.19.15.31.33\r\n
           \       for <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\n        (version=TLSv1.2
           cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);\r\n        Mon, 19 Jan
-          2015 11:59:27 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 14:59:25 -0500\r\nFrom:
+          2015 15:31:34 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 18:31:32 -0500\r\nFrom:
           ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nTo: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nMessage-ID:
-          <54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
+          <54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
           1.0\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding:
           7bit\r\n\r\nYeah, hello there!\r\n"
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:

--- a/spec/recordings/gmail_message/instance_methods/should_be_able_to_delete_itself.yml
+++ b/spec/recordings/gmail_message/instance_methods/should_be_able_to_delete_itself.yml
@@ -161,25 +161,25 @@ SELECT-6e4aa0e4422393e73c74d4645fd3834e:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 6
+        data: 7
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13273'
+        data: '14840'
       text: ''
     PERMANENTFLAGS: &6
     - *2
     UIDVALIDITY: &7
     - 2
     EXISTS: &8
-    - 3
+    - 4
     RECENT: &9
     - 0
     UIDNEXT: &10
-    - 6
+    - 7
     HIGHESTMODSEQ: &11
-    - '13273'
+    - '14840'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0009
@@ -220,25 +220,25 @@ SELECT-6e4aa0e4422393e73c74d4645fd3834e:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 7
+        data: 8
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13314'
+        data: '14878'
       text: ''
     PERMANENTFLAGS: &14
     - *3
     UIDVALIDITY: &15
     - 2
     EXISTS: &16
-    - 4
+    - 5
     RECENT: &17
     - 0
     UIDNEXT: &18
-    - 7
+    - 8
     HIGHESTMODSEQ: &19
-    - '13314'
+    - '14878'
 UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -260,6 +260,7 @@ UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
     - - 3
       - 4
       - 5
+      - 6
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0010
@@ -281,6 +282,7 @@ UID SEARCH-b19658413e2b63d2bac9c290a67c2cb3:
       - 4
       - 5
       - 6
+      - 7
 SELECT-868fce8856c91e50bebd43b4dbd8e071:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -322,25 +324,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13273'
+        data: '14840'
       text: ''
     PERMANENTFLAGS: &24
     - *20
     UIDVALIDITY: &25
     - 11
     EXISTS: &26
-    - 150
+    - 181
     RECENT: &27
     - 0
     UIDNEXT: &28
-    - 157
+    - 190
     HIGHESTMODSEQ: &29
-    - '13273'
+    - '14840'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0007
@@ -381,26 +383,26 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13273'
+        data: '14840'
       text: ''
     PERMANENTFLAGS: &32
     - *21
     UIDVALIDITY: &33
     - 11
     EXISTS: &34
-    - 150
-    - 149
+    - 181
+    - 180
     RECENT: &35
     - 0
     UIDNEXT: &36
-    - 157
+    - 190
     HIGHESTMODSEQ: &37
-    - '13273'
+    - '14840'
 UID SEARCH-0010f3078427015fc193bf14c1871582:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -556,8 +558,34 @@ UID SEARCH-0010f3078427015fc193bf14c1871582:
       - 143
       - 144
       - 145
-      - 146
-UID STORE-d2492cde05f51b3f9fade29407d3c470:
+      - 157
+      - 158
+      - 159
+      - 160
+      - 161
+      - 162
+      - 166
+      - 167
+      - 168
+      - 169
+      - 170
+      - 171
+      - 172
+      - 173
+      - 174
+      - 175
+      - 176
+      - 177
+      - 178
+      - 179
+      - 180
+      - 181
+      - 182
+      - 183
+      - 184
+      - 185
+      - 188
+UID STORE-5f00644f03823fab3d1e9602aa792384:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0008
@@ -576,16 +604,16 @@ UID STORE-d2492cde05f51b3f9fade29407d3c470:
     HIGHESTMODSEQ: *37
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 146
+      seqno: 180
       attr:
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - "\\Trash"
-        UID: 146
+        UID: 188
     EXPUNGE:
-    - 146
+    - 180
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse

--- a/spec/recordings/gmail_message/instance_methods/should_be_able_to_mark_itself_read.yml
+++ b/spec/recordings/gmail_message/instance_methods/should_be_able_to_mark_itself_read.yml
@@ -161,25 +161,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 166
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13712'
+        data: '14762'
       text: ''
     PERMANENTFLAGS: &8
     - *2
     UIDVALIDITY: &9
     - 11
     EXISTS: &10
-    - 158
+    - 181
     RECENT: &11
     - 0
     UIDNEXT: &12
-    - 166
+    - 190
     HIGHESTMODSEQ: &13
-    - '13712'
+    - '14762'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0005
@@ -220,25 +220,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 166
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13712'
+        data: '14762'
       text: ''
     PERMANENTFLAGS: &16
     - *3
     UIDVALIDITY: &17
     - 11
     EXISTS: &18
-    - 158
+    - 181
     RECENT: &19
     - 0
     UIDNEXT: &20
-    - 166
+    - 190
     HIGHESTMODSEQ: &21
-    - '13712'
+    - '14762'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0007
@@ -279,25 +279,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 166
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13712'
+        data: '14762'
       text: ''
     PERMANENTFLAGS: &24
     - *4
     UIDVALIDITY: &25
     - 11
     EXISTS: &26
-    - 158
+    - 181
     RECENT: &27
     - 0
     UIDNEXT: &28
-    - 166
+    - 190
     HIGHESTMODSEQ: &29
-    - '13712'
+    - '14762'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0009
@@ -338,25 +338,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 166
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13738'
+        data: '14790'
       text: ''
     PERMANENTFLAGS: &32
     - *5
     UIDVALIDITY: &33
     - 11
     EXISTS: &34
-    - 158
+    - 181
     RECENT: &35
     - 0
     UIDNEXT: &36
-    - 166
+    - 190
     HIGHESTMODSEQ: &37
-    - '13738'
+    - '14790'
 UID SEARCH-0010f3078427015fc193bf14c1871582:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -518,8 +518,29 @@ UID SEARCH-0010f3078427015fc193bf14c1871582:
       - 160
       - 161
       - 162
-      - 163
-UID STORE-968c28eba14929db9ed391d743ddd9da:
+      - 166
+      - 167
+      - 168
+      - 169
+      - 170
+      - 171
+      - 172
+      - 173
+      - 174
+      - 175
+      - 176
+      - 177
+      - 178
+      - 179
+      - 180
+      - 181
+      - 182
+      - 183
+      - 184
+      - 185
+      - 188
+      - 189
+UID STORE-d8856adb08eff0ce87ddc481f1fea47b:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0006
@@ -538,11 +559,11 @@ UID STORE-968c28eba14929db9ed391d743ddd9da:
     HIGHESTMODSEQ: *21
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 156
+      seqno: 181
       attr:
         FLAGS: []
-        UID: 163
-UID STORE-c26478f1a9d85899a8685cc3e5c2bf59:
+        UID: 189
+UID STORE-9bd5602a8ebeadd967771238ca71a706:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0008
@@ -561,12 +582,12 @@ UID STORE-c26478f1a9d85899a8685cc3e5c2bf59:
     HIGHESTMODSEQ: *29
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 156
+      seqno: 181
       attr:
         FLAGS:
         - :Seen
-        UID: 163
-UID FETCH-f80ccabc64942b0e39a6290d626f776d:
+        UID: 189
+UID FETCH-c91d19726aebc8362537324efef9b96b:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0010
@@ -585,18 +606,20 @@ UID FETCH-f80ccabc64942b0e39a6290d626f776d:
     HIGHESTMODSEQ: *37
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 156
+      seqno: 181
       attr:
-        X-GM-MSGID: 1490760667114478536
+        X-GM-THRID: 1490771293684090059
+        X-GM-MSGID: 1490771293684090059
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
-        UID: 163
+        - Great
+        UID: 189
         FLAGS:
         - :Seen
         ENVELOPE: !ruby/struct:Net::IMAP::Envelope
-          date: Mon, 19 Jan 2015 20:42:38 +0000
+          date: Mon, 19 Jan 2015 18:31:32 -0500
           subject: Hello world!
           from:
           - !ruby/struct:Net::IMAP::Address
@@ -625,16 +648,16 @@ UID FETCH-f80ccabc64942b0e39a6290d626f776d:
           cc: 
           bcc: 
           in_reply_to: 
-          message_id: "<54bd6c3e3e4f7_86ab9a000672@testing-worker-linux-9-2-24875-linux-3-47566185.mail>"
+          message_id: "<54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>"
         BODY[]: "Return-Path: <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nReceived:
-          from gmail.com (testing-worker-linux-9-2-24875-linux-3-47566185.c45665.blueboxgrid.com.
-          [2607:f700:8001:134:d931:6fab:10db:a91d])\r\n        by mx.google.com with
-          ESMTPSA id o59sm13278169qga.0.2015.01.19.12.42.39\r\n        for <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\n
-          \       (version=TLSv1.1 cipher=ECDHE-RSA-RC4-SHA bits=128/128);\r\n        Mon,
-          19 Jan 2015 12:42:39 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 20:42:38 +0000\r\nFrom:
+          from gmail.com (99-156-120-246.lightspeed.miamfl.sbcglobal.net. [99.156.120.246])\r\n
+          \       by mx.google.com with ESMTPSA id a15sm890292oic.18.2015.01.19.15.31.33\r\n
+          \       for <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\n        (version=TLSv1.2
+          cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);\r\n        Mon, 19 Jan
+          2015 15:31:34 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 18:31:32 -0500\r\nFrom:
           ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nTo: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nMessage-ID:
-          <54bd6c3e3e4f7_86ab9a000672@testing-worker-linux-9-2-24875-linux-3-47566185.mail>\r\nSubject:
-          Hello world!\r\nMime-Version: 1.0\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding:
+          <54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
+          1.0\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding:
           7bit\r\n\r\nYeah, hello there!\r\n"
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
 - - :return

--- a/spec/recordings/gmail_message/instance_methods/should_be_able_to_mark_itself_unread.yml
+++ b/spec/recordings/gmail_message/instance_methods/should_be_able_to_mark_itself_unread.yml
@@ -161,25 +161,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 166
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13738'
+        data: '14790'
       text: ''
     PERMANENTFLAGS: &8
     - *2
     UIDVALIDITY: &9
     - 11
     EXISTS: &10
-    - 158
+    - 181
     RECENT: &11
     - 0
     UIDNEXT: &12
-    - 166
+    - 190
     HIGHESTMODSEQ: &13
-    - '13738'
+    - '14790'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0005
@@ -220,25 +220,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 166
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13738'
+        data: '14790'
       text: ''
     PERMANENTFLAGS: &16
     - *3
     UIDVALIDITY: &17
     - 11
     EXISTS: &18
-    - 158
+    - 181
     RECENT: &19
     - 0
     UIDNEXT: &20
-    - 166
+    - 190
     HIGHESTMODSEQ: &21
-    - '13738'
+    - '14790'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0007
@@ -279,25 +279,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 166
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13764'
+        data: '14815'
       text: ''
     PERMANENTFLAGS: &24
     - *4
     UIDVALIDITY: &25
     - 11
     EXISTS: &26
-    - 158
+    - 181
     RECENT: &27
     - 0
     UIDNEXT: &28
-    - 166
+    - 190
     HIGHESTMODSEQ: &29
-    - '13764'
+    - '14815'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0009
@@ -338,25 +338,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 166
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13789'
+        data: '14840'
       text: ''
     PERMANENTFLAGS: &32
     - *5
     UIDVALIDITY: &33
     - 11
     EXISTS: &34
-    - 158
+    - 181
     RECENT: &35
     - 0
     UIDNEXT: &36
-    - 166
+    - 190
     HIGHESTMODSEQ: &37
-    - '13789'
+    - '14840'
 UID SEARCH-0010f3078427015fc193bf14c1871582:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -518,7 +518,28 @@ UID SEARCH-0010f3078427015fc193bf14c1871582:
       - 160
       - 161
       - 162
-UID STORE-ddb88f3172d5bb115809ee0b040c37f8:
+      - 166
+      - 167
+      - 168
+      - 169
+      - 170
+      - 171
+      - 172
+      - 173
+      - 174
+      - 175
+      - 176
+      - 177
+      - 178
+      - 179
+      - 180
+      - 181
+      - 182
+      - 183
+      - 184
+      - 185
+      - 188
+UID STORE-496a62292a2518ec1012e07027b7f91f:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0006
@@ -537,12 +558,12 @@ UID STORE-ddb88f3172d5bb115809ee0b040c37f8:
     HIGHESTMODSEQ: *21
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 155
+      seqno: 180
       attr:
         FLAGS:
         - :Seen
-        UID: 162
-UID STORE-f0b183701830007ca6303f8d74f91858:
+        UID: 188
+UID STORE-31222f58bd384a4fada4385c5e4576c6:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0008
@@ -561,11 +582,11 @@ UID STORE-f0b183701830007ca6303f8d74f91858:
     HIGHESTMODSEQ: *29
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 155
+      seqno: 180
       attr:
         FLAGS: []
-        UID: 162
-UID FETCH-9dd010b55de4a912b78fa9c902196b98:
+        UID: 188
+UID FETCH-47e3d4cc32db0f62bccc2a0220605acc:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0010
@@ -584,56 +605,64 @@ UID FETCH-9dd010b55de4a912b78fa9c902196b98:
     HIGHESTMODSEQ: *37
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 155
+      seqno: 180
       attr:
-        X-GM-MSGID: 1490760663368158888
+        X-GM-THRID: 1490770850496356226
+        X-GM-MSGID: 1490771115289978288
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
-        UID: 162
+        UID: 188
         FLAGS: []
         ENVELOPE: !ruby/struct:Net::IMAP::Envelope
-          date: Mon, 19 Jan 2015 20:42:35 +0000
-          subject: Hello world!
+          date: Mon, 19 Jan 2015 18:28:44 -0500
+          subject: 'Re: Hello world!'
           from:
           - !ruby/struct:Net::IMAP::Address
-            name: 
+            name: John Doe
             route: 
             mailbox: ki0zvkyi1yzgy7xu4f4dh46nqrcecm
             host: gmail.com
           sender:
           - !ruby/struct:Net::IMAP::Address
-            name: 
+            name: John Doe
             route: 
             mailbox: ki0zvkyi1yzgy7xu4f4dh46nqrcecm
             host: gmail.com
           reply_to:
           - !ruby/struct:Net::IMAP::Address
-            name: 
+            name: John Doe
             route: 
             mailbox: ki0zvkyi1yzgy7xu4f4dh46nqrcecm
             host: gmail.com
           to:
           - !ruby/struct:Net::IMAP::Address
-            name: 
+            name: John Doe
             route: 
             mailbox: ki0zvkyi1yzgy7xu4f4dh46nqrcecm
             host: gmail.com
           cc: 
           bcc: 
-          in_reply_to: 
-          message_id: "<54bd6c3b5dddf_86c108be88184e9@testing-worker-linux-9-2-24875-linux-11-47566186.mail>"
-        BODY[]: "Return-Path: <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nReceived:
-          from gmail.com (testing-worker-linux-9-2-24875-linux-11-47566186.c45665.blueboxgrid.com.
-          [2607:f700:8001:134:1fa1:72fc:47a4:9ce])\r\n        by mx.google.com with
-          ESMTPSA id v16sm13260674qaw.30.2015.01.19.12.42.36\r\n        for <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\n
-          \       (version=TLSv1.1 cipher=ECDHE-RSA-RC4-SHA bits=128/128);\r\n        Mon,
-          19 Jan 2015 12:42:36 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 20:42:35 +0000\r\nFrom:
-          ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nTo: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nMessage-ID:
-          <54bd6c3b5dddf_86c108be88184e9@testing-worker-linux-9-2-24875-linux-11-47566186.mail>\r\nSubject:
-          Hello world!\r\nMime-Version: 1.0\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding:
-          7bit\r\n\r\nYeah, hello there!\r\n"
+          in_reply_to: "<54bd922ea931d_84b7f3988504b6@testing-worker-linux-de84ae74-1-8451-linux-10-47583278.mail>"
+          message_id: "<CACNRAYLB0c8Hv2yhCLahhiVmvsGXPZVL73tbed4k_mAO-SmKYQ@mail.gmail.com>"
+        BODY[]: "MIME-Version: 1.0\r\nReceived: by 10.194.209.232 with HTTP; Mon,
+          19 Jan 2015 15:28:44 -0800 (PST)\r\nIn-Reply-To: <54bd922ea931d_84b7f3988504b6@testing-worker-linux-de84ae74-1-8451-linux-10-47583278.mail>\r\nReferences:
+          <54bd922ea931d_84b7f3988504b6@testing-worker-linux-de84ae74-1-8451-linux-10-47583278.mail>\r\nDate:
+          Mon, 19 Jan 2015 18:28:44 -0500\r\nDelivered-To: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nMessage-ID:
+          <CACNRAYLB0c8Hv2yhCLahhiVmvsGXPZVL73tbed4k_mAO-SmKYQ@mail.gmail.com>\r\nSubject:
+          Re: Hello world!\r\nFrom: John Doe <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nTo:
+          John Doe <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nContent-Type: multipart/alternative;
+          boundary=047d7ba9798cee15fc050d09ae9e\r\n\r\n--047d7ba9798cee15fc050d09ae9e\r\nContent-Type:
+          text/plain; charset=UTF-8\r\n\r\nAnother message in the thread!\r\n\r\nOn
+          Mon, Jan 19, 2015 at 6:24 PM, <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nwrote:\r\n\r\n>
+          Yeah, hello there!\r\n>\r\n\r\n--047d7ba9798cee15fc050d09ae9e\r\nContent-Type:
+          text/html; charset=UTF-8\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n<div
+          dir=3D\"ltr\">Another message in the thread!</div><div class=3D\"gmail_ex=\r\ntra\"><br><div
+          class=3D\"gmail_quote\">On Mon, Jan 19, 2015 at 6:24 PM,  <span=\r\n dir=3D\"ltr\">&lt;<a
+          href=3D\"mailto:ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com=\r\n\" target=3D\"_blank\">ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com</a>&gt;</span>=\r\n
+          wrote:<br><blockquote class=3D\"gmail_quote\" style=3D\"margin:0 0 0 .8ex;bor=\r\nder-left:1px
+          #ccc solid;padding-left:1ex\">Yeah, hello there!<br>\r\n</blockquote></div><br></div>\r\n\r\n--047d7ba9798cee15fc050d09ae9e--"
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse

--- a/spec/recordings/gmail_message/instance_methods/should_be_able_to_set_given_label.yml
+++ b/spec/recordings/gmail_message/instance_methods/should_be_able_to_set_given_label.yml
@@ -161,25 +161,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13189'
+        data: '14699'
       text: ''
     PERMANENTFLAGS: &8
     - *2
     UIDVALIDITY: &9
     - 11
     EXISTS: &10
-    - 150
+    - 181
     RECENT: &11
     - 0
     UIDNEXT: &12
-    - 157
+    - 190
     HIGHESTMODSEQ: &13
-    - '13189'
+    - '14699'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0005
@@ -220,25 +220,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13189'
+        data: '14699'
       text: ''
     PERMANENTFLAGS: &16
     - *3
     UIDVALIDITY: &17
     - 11
     EXISTS: &18
-    - 150
+    - 181
     RECENT: &19
     - 0
     UIDNEXT: &20
-    - 157
+    - 190
     HIGHESTMODSEQ: &21
-    - '13189'
+    - '14699'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0007
@@ -279,25 +279,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13196'
+        data: '14706'
       text: ''
     PERMANENTFLAGS: &24
     - *4
     UIDVALIDITY: &25
     - 11
     EXISTS: &26
-    - 150
+    - 181
     RECENT: &27
     - 0
     UIDNEXT: &28
-    - 157
+    - 190
     HIGHESTMODSEQ: &29
-    - '13196'
+    - '14706'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0009
@@ -338,25 +338,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13196'
+        data: '14713'
       text: ''
     PERMANENTFLAGS: &32
     - *5
     UIDVALIDITY: &33
     - 11
     EXISTS: &34
-    - 150
+    - 181
     RECENT: &35
     - 0
     UIDNEXT: &36
-    - 157
+    - 190
     HIGHESTMODSEQ: &37
-    - '13196'
+    - '14713'
 UID SEARCH-0010f3078427015fc193bf14c1871582:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -512,9 +512,35 @@ UID SEARCH-0010f3078427015fc193bf14c1871582:
       - 143
       - 144
       - 145
-      - 146
-      - 156
-UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
+      - 157
+      - 158
+      - 159
+      - 160
+      - 161
+      - 162
+      - 166
+      - 167
+      - 168
+      - 169
+      - 170
+      - 171
+      - 172
+      - 173
+      - 174
+      - 175
+      - 176
+      - 177
+      - 178
+      - 179
+      - 180
+      - 181
+      - 182
+      - 183
+      - 184
+      - 185
+      - 188
+      - 189
+UID STORE-ac884ffbfb66da354d64b0f2d42a166f:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0006
@@ -533,16 +559,15 @@ UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
     HIGHESTMODSEQ: *21
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Awesome
-        - Great
-        UID: 156
-UID STORE-643ffd7492792039322aa146f528ae70:
+        UID: 189
+UID STORE-c2d6f8de722e6c9f06f0a6a1a4163f69:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0008
@@ -561,7 +586,7 @@ UID STORE-643ffd7492792039322aa146f528ae70:
     HIGHESTMODSEQ: *29
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
@@ -569,8 +594,8 @@ UID STORE-643ffd7492792039322aa146f528ae70:
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
-UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
+        UID: 189
+UID FETCH-c91d19726aebc8362537324efef9b96b:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0010
@@ -589,19 +614,20 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
     HIGHESTMODSEQ: *37
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
-        X-GM-MSGID: 1490757948419620310
+        X-GM-THRID: 1490771293684090059
+        X-GM-MSGID: 1490771293684090059
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
+        UID: 189
         FLAGS: []
         ENVELOPE: !ruby/struct:Net::IMAP::Envelope
-          date: Mon, 19 Jan 2015 14:59:25 -0500
+          date: Mon, 19 Jan 2015 18:31:32 -0500
           subject: Hello world!
           from:
           - !ruby/struct:Net::IMAP::Address
@@ -630,15 +656,15 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
           cc: 
           bcc: 
           in_reply_to: 
-          message_id: "<54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>"
+          message_id: "<54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>"
         BODY[]: "Return-Path: <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nReceived:
           from gmail.com (99-156-120-246.lightspeed.miamfl.sbcglobal.net. [99.156.120.246])\r\n
-          \       by mx.google.com with ESMTPSA id nt5sm6321261obb.26.2015.01.19.11.59.26\r\n
+          \       by mx.google.com with ESMTPSA id a15sm890292oic.18.2015.01.19.15.31.33\r\n
           \       for <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\n        (version=TLSv1.2
           cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);\r\n        Mon, 19 Jan
-          2015 11:59:27 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 14:59:25 -0500\r\nFrom:
+          2015 15:31:34 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 18:31:32 -0500\r\nFrom:
           ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nTo: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nMessage-ID:
-          <54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
+          <54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
           1.0\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding:
           7bit\r\n\r\nYeah, hello there!\r\n"
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:

--- a/spec/recordings/gmail_message/instance_methods/should_be_able_to_set_given_label_with_old_method.yml
+++ b/spec/recordings/gmail_message/instance_methods/should_be_able_to_set_given_label_with_old_method.yml
@@ -161,25 +161,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13203'
+        data: '14720'
       text: ''
     PERMANENTFLAGS: &8
     - *2
     UIDVALIDITY: &9
     - 11
     EXISTS: &10
-    - 150
+    - 181
     RECENT: &11
     - 0
     UIDNEXT: &12
-    - 157
+    - 190
     HIGHESTMODSEQ: &13
-    - '13203'
+    - '14720'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0005
@@ -220,25 +220,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13203'
+        data: '14720'
       text: ''
     PERMANENTFLAGS: &16
     - *3
     UIDVALIDITY: &17
     - 11
     EXISTS: &18
-    - 150
+    - 181
     RECENT: &19
     - 0
     UIDNEXT: &20
-    - 157
+    - 190
     HIGHESTMODSEQ: &21
-    - '13203'
+    - '14720'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0007
@@ -279,25 +279,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13210'
+        data: '14727'
       text: ''
     PERMANENTFLAGS: &24
     - *4
     UIDVALIDITY: &25
     - 11
     EXISTS: &26
-    - 150
+    - 181
     RECENT: &27
     - 0
     UIDNEXT: &28
-    - 157
+    - 190
     HIGHESTMODSEQ: &29
-    - '13210'
+    - '14727'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0009
@@ -338,25 +338,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13210'
+        data: '14727'
       text: ''
     PERMANENTFLAGS: &32
     - *5
     UIDVALIDITY: &33
     - 11
     EXISTS: &34
-    - 150
+    - 181
     RECENT: &35
     - 0
     UIDNEXT: &36
-    - 157
+    - 190
     HIGHESTMODSEQ: &37
-    - '13210'
+    - '14727'
 UID SEARCH-0010f3078427015fc193bf14c1871582:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -512,9 +512,35 @@ UID SEARCH-0010f3078427015fc193bf14c1871582:
       - 143
       - 144
       - 145
-      - 146
-      - 156
-UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
+      - 157
+      - 158
+      - 159
+      - 160
+      - 161
+      - 162
+      - 166
+      - 167
+      - 168
+      - 169
+      - 170
+      - 171
+      - 172
+      - 173
+      - 174
+      - 175
+      - 176
+      - 177
+      - 178
+      - 179
+      - 180
+      - 181
+      - 182
+      - 183
+      - 184
+      - 185
+      - 188
+      - 189
+UID STORE-ac884ffbfb66da354d64b0f2d42a166f:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0006
@@ -533,7 +559,7 @@ UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
     HIGHESTMODSEQ: *21
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
@@ -541,8 +567,8 @@ UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
-UID STORE-643ffd7492792039322aa146f528ae70:
+        UID: 189
+UID STORE-c2d6f8de722e6c9f06f0a6a1a4163f69:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0008
@@ -561,7 +587,7 @@ UID STORE-643ffd7492792039322aa146f528ae70:
     HIGHESTMODSEQ: *29
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
@@ -569,8 +595,8 @@ UID STORE-643ffd7492792039322aa146f528ae70:
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
-UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
+        UID: 189
+UID FETCH-c91d19726aebc8362537324efef9b96b:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0010
@@ -589,19 +615,20 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
     HIGHESTMODSEQ: *37
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
-        X-GM-MSGID: 1490757948419620310
+        X-GM-THRID: 1490771293684090059
+        X-GM-MSGID: 1490771293684090059
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
+        UID: 189
         FLAGS: []
         ENVELOPE: !ruby/struct:Net::IMAP::Envelope
-          date: Mon, 19 Jan 2015 14:59:25 -0500
+          date: Mon, 19 Jan 2015 18:31:32 -0500
           subject: Hello world!
           from:
           - !ruby/struct:Net::IMAP::Address
@@ -630,15 +657,15 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
           cc: 
           bcc: 
           in_reply_to: 
-          message_id: "<54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>"
+          message_id: "<54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>"
         BODY[]: "Return-Path: <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nReceived:
           from gmail.com (99-156-120-246.lightspeed.miamfl.sbcglobal.net. [99.156.120.246])\r\n
-          \       by mx.google.com with ESMTPSA id nt5sm6321261obb.26.2015.01.19.11.59.26\r\n
+          \       by mx.google.com with ESMTPSA id a15sm890292oic.18.2015.01.19.15.31.33\r\n
           \       for <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\n        (version=TLSv1.2
           cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);\r\n        Mon, 19 Jan
-          2015 11:59:27 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 14:59:25 -0500\r\nFrom:
+          2015 15:31:34 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 18:31:32 -0500\r\nFrom:
           ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nTo: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nMessage-ID:
-          <54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
+          <54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
           1.0\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding:
           7bit\r\n\r\nYeah, hello there!\r\n"
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:

--- a/spec/recordings/gmail_message/instance_methods/should_remove_a_given_label.yml
+++ b/spec/recordings/gmail_message/instance_methods/should_remove_a_given_label.yml
@@ -161,25 +161,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13196'
+        data: '14713'
       text: ''
     PERMANENTFLAGS: &9
     - *2
     UIDVALIDITY: &10
     - 11
     EXISTS: &11
-    - 150
+    - 181
     RECENT: &12
     - 0
     UIDNEXT: &13
-    - 157
+    - 190
     HIGHESTMODSEQ: &14
-    - '13196'
+    - '14713'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0005
@@ -220,25 +220,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13196'
+        data: '14713'
       text: ''
     PERMANENTFLAGS: &17
     - *3
     UIDVALIDITY: &18
     - 11
     EXISTS: &19
-    - 150
+    - 181
     RECENT: &20
     - 0
     UIDNEXT: &21
-    - 157
+    - 190
     HIGHESTMODSEQ: &22
-    - '13196'
+    - '14713'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0007
@@ -279,25 +279,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13196'
+        data: '14713'
       text: ''
     PERMANENTFLAGS: &25
     - *4
     UIDVALIDITY: &26
     - 11
     EXISTS: &27
-    - 150
+    - 181
     RECENT: &28
     - 0
     UIDNEXT: &29
-    - 157
+    - 190
     HIGHESTMODSEQ: &30
-    - '13196'
+    - '14713'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0009
@@ -338,25 +338,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13196'
+        data: '14713'
       text: ''
     PERMANENTFLAGS: &33
     - *5
     UIDVALIDITY: &34
     - 11
     EXISTS: &35
-    - 150
+    - 181
     RECENT: &36
     - 0
     UIDNEXT: &37
-    - 157
+    - 190
     HIGHESTMODSEQ: &38
-    - '13196'
+    - '14713'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0011
@@ -397,25 +397,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13203'
+        data: '14720'
       text: ''
     PERMANENTFLAGS: &41
     - *6
     UIDVALIDITY: &42
     - 11
     EXISTS: &43
-    - 150
+    - 181
     RECENT: &44
     - 0
     UIDNEXT: &45
-    - 157
+    - 190
     HIGHESTMODSEQ: &46
-    - '13203'
+    - '14720'
 UID SEARCH-0010f3078427015fc193bf14c1871582:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -571,9 +571,35 @@ UID SEARCH-0010f3078427015fc193bf14c1871582:
       - 143
       - 144
       - 145
-      - 146
-      - 156
-UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
+      - 157
+      - 158
+      - 159
+      - 160
+      - 161
+      - 162
+      - 166
+      - 167
+      - 168
+      - 169
+      - 170
+      - 171
+      - 172
+      - 173
+      - 174
+      - 175
+      - 176
+      - 177
+      - 178
+      - 179
+      - 180
+      - 181
+      - 182
+      - 183
+      - 184
+      - 185
+      - 188
+      - 189
+UID STORE-ac884ffbfb66da354d64b0f2d42a166f:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0006
@@ -592,7 +618,7 @@ UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
     HIGHESTMODSEQ: *22
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
@@ -600,8 +626,8 @@ UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
-UID STORE-643ffd7492792039322aa146f528ae70:
+        UID: 189
+UID STORE-c2d6f8de722e6c9f06f0a6a1a4163f69:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0008
@@ -620,7 +646,7 @@ UID STORE-643ffd7492792039322aa146f528ae70:
     HIGHESTMODSEQ: *30
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
@@ -628,8 +654,8 @@ UID STORE-643ffd7492792039322aa146f528ae70:
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
-UID STORE-3183f490549e85f11879b2f1e2e7cdce:
+        UID: 189
+UID STORE-2e46c35991051e7831af457bc2435903:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0010
@@ -648,15 +674,15 @@ UID STORE-3183f490549e85f11879b2f1e2e7cdce:
     HIGHESTMODSEQ: *38
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Great
-        UID: 156
-UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
+        UID: 189
+UID FETCH-c91d19726aebc8362537324efef9b96b:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0012
@@ -675,18 +701,19 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
     HIGHESTMODSEQ: *46
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
-        X-GM-MSGID: 1490757948419620310
+        X-GM-THRID: 1490771293684090059
+        X-GM-MSGID: 1490771293684090059
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Great
-        UID: 156
+        UID: 189
         FLAGS: []
         ENVELOPE: !ruby/struct:Net::IMAP::Envelope
-          date: Mon, 19 Jan 2015 14:59:25 -0500
+          date: Mon, 19 Jan 2015 18:31:32 -0500
           subject: Hello world!
           from:
           - !ruby/struct:Net::IMAP::Address
@@ -715,15 +742,15 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
           cc: 
           bcc: 
           in_reply_to: 
-          message_id: "<54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>"
+          message_id: "<54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>"
         BODY[]: "Return-Path: <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nReceived:
           from gmail.com (99-156-120-246.lightspeed.miamfl.sbcglobal.net. [99.156.120.246])\r\n
-          \       by mx.google.com with ESMTPSA id nt5sm6321261obb.26.2015.01.19.11.59.26\r\n
+          \       by mx.google.com with ESMTPSA id a15sm890292oic.18.2015.01.19.15.31.33\r\n
           \       for <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\n        (version=TLSv1.2
           cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);\r\n        Mon, 19 Jan
-          2015 11:59:27 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 14:59:25 -0500\r\nFrom:
+          2015 15:31:34 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 18:31:32 -0500\r\nFrom:
           ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nTo: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nMessage-ID:
-          <54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
+          <54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
           1.0\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding:
           7bit\r\n\r\nYeah, hello there!\r\n"
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:

--- a/spec/recordings/gmail_message/instance_methods/should_remove_a_given_label_with_old_method.yml
+++ b/spec/recordings/gmail_message/instance_methods/should_remove_a_given_label_with_old_method.yml
@@ -161,25 +161,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13210'
+        data: '14727'
       text: ''
     PERMANENTFLAGS: &9
     - *2
     UIDVALIDITY: &10
     - 11
     EXISTS: &11
-    - 150
+    - 181
     RECENT: &12
     - 0
     UIDNEXT: &13
-    - 157
+    - 190
     HIGHESTMODSEQ: &14
-    - '13210'
+    - '14727'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0005
@@ -220,25 +220,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13210'
+        data: '14727'
       text: ''
     PERMANENTFLAGS: &17
     - *3
     UIDVALIDITY: &18
     - 11
     EXISTS: &19
-    - 150
+    - 181
     RECENT: &20
     - 0
     UIDNEXT: &21
-    - 157
+    - 190
     HIGHESTMODSEQ: &22
-    - '13210'
+    - '14727'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0007
@@ -279,25 +279,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13210'
+        data: '14727'
       text: ''
     PERMANENTFLAGS: &25
     - *4
     UIDVALIDITY: &26
     - 11
     EXISTS: &27
-    - 150
+    - 181
     RECENT: &28
     - 0
     UIDNEXT: &29
-    - 157
+    - 190
     HIGHESTMODSEQ: &30
-    - '13210'
+    - '14727'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0009
@@ -338,25 +338,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13210'
+        data: '14727'
       text: ''
     PERMANENTFLAGS: &33
     - *5
     UIDVALIDITY: &34
     - 11
     EXISTS: &35
-    - 150
+    - 181
     RECENT: &36
     - 0
     UIDNEXT: &37
-    - 157
+    - 190
     HIGHESTMODSEQ: &38
-    - '13210'
+    - '14727'
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0011
@@ -397,25 +397,25 @@ SELECT-868fce8856c91e50bebd43b4dbd8e071:
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: UIDNEXT
-        data: 157
+        data: 190
       text: " Predicted next UID."
     - !ruby/struct:Net::IMAP::ResponseText
       code: !ruby/struct:Net::IMAP::ResponseCode
         name: HIGHESTMODSEQ
-        data: '13217'
+        data: '14734'
       text: ''
     PERMANENTFLAGS: &41
     - *6
     UIDVALIDITY: &42
     - 11
     EXISTS: &43
-    - 150
+    - 181
     RECENT: &44
     - 0
     UIDNEXT: &45
-    - 157
+    - 190
     HIGHESTMODSEQ: &46
-    - '13217'
+    - '14734'
 UID SEARCH-0010f3078427015fc193bf14c1871582:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
@@ -571,9 +571,35 @@ UID SEARCH-0010f3078427015fc193bf14c1871582:
       - 143
       - 144
       - 145
-      - 146
-      - 156
-UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
+      - 157
+      - 158
+      - 159
+      - 160
+      - 161
+      - 162
+      - 166
+      - 167
+      - 168
+      - 169
+      - 170
+      - 171
+      - 172
+      - 173
+      - 174
+      - 175
+      - 176
+      - 177
+      - 178
+      - 179
+      - 180
+      - 181
+      - 182
+      - 183
+      - 184
+      - 185
+      - 188
+      - 189
+UID STORE-ac884ffbfb66da354d64b0f2d42a166f:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0006
@@ -592,7 +618,7 @@ UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
     HIGHESTMODSEQ: *22
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
@@ -600,8 +626,8 @@ UID STORE-a01a114d5b75f4cd2821e42fdbe3edb0:
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
-UID STORE-643ffd7492792039322aa146f528ae70:
+        UID: 189
+UID STORE-c2d6f8de722e6c9f06f0a6a1a4163f69:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0008
@@ -620,7 +646,7 @@ UID STORE-643ffd7492792039322aa146f528ae70:
     HIGHESTMODSEQ: *30
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
@@ -628,8 +654,8 @@ UID STORE-643ffd7492792039322aa146f528ae70:
         - "\\Sent"
         - Awesome
         - Great
-        UID: 156
-UID STORE-3183f490549e85f11879b2f1e2e7cdce:
+        UID: 189
+UID STORE-2e46c35991051e7831af457bc2435903:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0010
@@ -648,15 +674,15 @@ UID STORE-3183f490549e85f11879b2f1e2e7cdce:
     HIGHESTMODSEQ: *38
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Great
-        UID: 156
-UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
+        UID: 189
+UID FETCH-c91d19726aebc8362537324efef9b96b:
 - - :return
   - !ruby/struct:Net::IMAP::TaggedResponse
     tag: RUBY0012
@@ -675,18 +701,19 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
     HIGHESTMODSEQ: *46
     FETCH:
     - !ruby/struct:Net::IMAP::FetchData
-      seqno: 150
+      seqno: 181
       attr:
-        X-GM-MSGID: 1490757948419620310
+        X-GM-THRID: 1490771293684090059
+        X-GM-MSGID: 1490771293684090059
         X-GM-LABELS:
         - "\\Important"
         - "\\Inbox"
         - "\\Sent"
         - Great
-        UID: 156
+        UID: 189
         FLAGS: []
         ENVELOPE: !ruby/struct:Net::IMAP::Envelope
-          date: Mon, 19 Jan 2015 14:59:25 -0500
+          date: Mon, 19 Jan 2015 18:31:32 -0500
           subject: Hello world!
           from:
           - !ruby/struct:Net::IMAP::Address
@@ -715,15 +742,15 @@ UID FETCH-50dbeed7750666a0a9aed7097875b6b1:
           cc: 
           bcc: 
           in_reply_to: 
-          message_id: "<54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>"
+          message_id: "<54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>"
         BODY[]: "Return-Path: <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\nReceived:
           from gmail.com (99-156-120-246.lightspeed.miamfl.sbcglobal.net. [99.156.120.246])\r\n
-          \       by mx.google.com with ESMTPSA id nt5sm6321261obb.26.2015.01.19.11.59.26\r\n
+          \       by mx.google.com with ESMTPSA id a15sm890292oic.18.2015.01.19.15.31.33\r\n
           \       for <ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com>\r\n        (version=TLSv1.2
           cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);\r\n        Mon, 19 Jan
-          2015 11:59:27 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 14:59:25 -0500\r\nFrom:
+          2015 15:31:34 -0800 (PST)\r\nDate: Mon, 19 Jan 2015 18:31:32 -0500\r\nFrom:
           ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nTo: ki0zvkyi1yzgy7xu4f4dh46nqrcecm@gmail.com\r\nMessage-ID:
-          <54bd621d70b54_37763fc6b8c65bec2d9@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
+          <54bd93d452c0f_74e73fc534c63bec5352@Jeffs-MBP.mail>\r\nSubject: Hello world!\r\nMime-Version:
           1.0\r\nContent-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding:
           7bit\r\n\r\nYeah, hello there!\r\n"
 LOGOUT-e76a09b7766d60a37ff9e1af527a143e:


### PR DESCRIPTION
Pull in the thread id via the X-GM-THRID param.

Also cleaned up a few things in the Gmail::Message class:
- added message_id alias to msg_id and thread_id alias to thr_id
- removed attr_reader declaration since we're explicitly defining getters (for memoization) for each of those fields
- corrected the usage of @message_id to @msg_id in `#inspect`