### PR TITLE
Add better specs to IMAP Gmail extension, and fix parsing labels with spaces

### DIFF
--- a/lib/gmail/imap_extensions.rb
+++ b/lib/gmail/imap_extensions.rb
@@ -67,11 +67,11 @@ module Gmail
             resp = extract_labels_response
 
             # We need to manually update the position of the regexp to prevent trip-ups
-            @pos += resp.length
+            @pos += resp.length - 1
 
             # `resp` will look something like this:
             # ("\\Inbox" "\\Sent" "one's and two's" "some new label" Awesome Ni&APE-os)
-            return resp.gsub(/^\s*\(|\)\s*$/, '').scan(/"([^"]*)"|([^\s"]+)/ni).flatten.compact.collect(&:unescape)
+            return resp.gsub(/^\s*\(|\)+\s*$/, '').scan(/"([^"]*)"|([^\s"]+)/ni).flatten.compact.collect(&:unescape)
           else
             parse_error("invalid label list")
           end

--- a/lib/gmail/imap_extensions.rb
+++ b/lib/gmail/imap_extensions.rb
@@ -1,5 +1,6 @@
 module Gmail
   module ImapExtensions
+    LABELS_FLAG_REGEXP = /\\([^\x80-\xff(){ \x00-\x1f\x7f%"\\]+)/n
     # Taken from https://github.com/oxos/gmail-oauth-thread-stats/blob/master/gmail_imap_extensions_compatibility.rb
     def self.patch_net_imap_response_parser(klass = Net::IMAP::ResponseParser)
       # https://github.com/ruby/ruby/blob/4d426fc2e03078d583d5d573d4863415c3e3eb8d/lib/net/imap.rb#L2258
@@ -71,7 +72,15 @@ module Gmail
 
             # `resp` will look something like this:
             # ("\\Inbox" "\\Sent" "one's and two's" "some new label" Awesome Ni&APE-os)
-            return resp.gsub(/^\s*\(|\)+\s*$/, '').scan(/"([^"]*)"|([^\s"]+)/ni).flatten.compact.collect(&:unescape)
+            result = resp.gsub(/^\s*\(|\)+\s*$/, '').scan(/"([^"]*)"|([^\s"]+)/ni).flatten.compact.collect(&:unescape)
+            result.map do |x|
+              flag = x.scan(LABELS_FLAG_REGEXP)
+              if flag.empty?
+                x
+              else
+                flag.first.first.capitalize.untaint.intern
+              end
+            end
           else
             parse_error("invalid label list")
           end

--- a/spec/gmail/imap_extensions_spec.rb
+++ b/spec/gmail/imap_extensions_spec.rb
@@ -9,4 +9,39 @@ describe Gmail::ImapExtensions do
     expect(Net::IMAP::ResponseParser.new).to respond_to(:msg_att).with(0).arguments
     expect(Net::IMAP::ResponseParser.new).to respond_to(:msg_att).with(1).arguments
   end
+
+  it 'parses 1 label without spaces correctly' do
+    Gmail::ImapExtensions::patch_net_imap_response_parser
+    server_response = %[* 1 FETCH (X-GM-LABELS (Hello))\r\n]
+    parsed_labels = Net::IMAP::ResponseParser.new.parse(server_response).data.attr["X-GM-LABELS"]
+    expect(parsed_labels).to contain_exactly("Hello")
+  end
+
+  it 'parses 2 label without spaces correctly' do
+    Gmail::ImapExtensions::patch_net_imap_response_parser
+    server_response = %[* 1 FETCH (X-GM-LABELS (Hello World))\r\n]
+    parsed_labels = Net::IMAP::ResponseParser.new.parse(server_response).data.attr["X-GM-LABELS"]
+    expect(parsed_labels).to contain_exactly("World", "Hello")
+  end
+
+  it 'parses 1 label with a space correctly' do
+    Gmail::ImapExtensions::patch_net_imap_response_parser
+    server_response = %[* 1 FETCH (X-GM-LABELS ("Hello World"))\r\n]
+    parsed_labels = Net::IMAP::ResponseParser.new.parse(server_response).data.attr["X-GM-LABELS"]
+    expect(parsed_labels).to contain_exactly("Hello World")
+  end
+
+  it 'parses 2 labels, each with a space, correctly' do
+    Gmail::ImapExtensions::patch_net_imap_response_parser
+    server_response = %[* 1 FETCH (X-GM-LABELS ("Foo Bar" "Hello World"))\r\n]
+    parsed_labels = Net::IMAP::ResponseParser.new.parse(server_response).data.attr["X-GM-LABELS"]
+    expect(parsed_labels).to contain_exactly("Hello World", "Foo Bar")
+  end
+
+  it 'parses a mixture of space and non-space labels correctly' do
+    Gmail::ImapExtensions::patch_net_imap_response_parser
+    server_response = %[* 1 FETCH (X-GM-LABELS ("Foo Bar" "\\Important" Hello World))\r\n]
+    parsed_labels = Net::IMAP::ResponseParser.new.parse(server_response).data.attr["X-GM-LABELS"]
+    expect(parsed_labels).to contain_exactly("\\Important", "Hello", "World", "Foo Bar")
+  end
 end

--- a/spec/gmail/imap_extensions_spec.rb
+++ b/spec/gmail/imap_extensions_spec.rb
@@ -42,6 +42,6 @@ describe Gmail::ImapExtensions do
     Gmail::ImapExtensions::patch_net_imap_response_parser
     server_response = %[* 1 FETCH (X-GM-LABELS ("Foo Bar" "\\Important" Hello World))\r\n]
     parsed_labels = Net::IMAP::ResponseParser.new.parse(server_response).data.attr["X-GM-LABELS"]
-    expect(parsed_labels).to contain_exactly("\\Important", "Hello", "World", "Foo Bar")
+    expect(parsed_labels).to contain_exactly(:Important, "Hello", "World", "Foo Bar")
   end
 end


### PR DESCRIPTION
This functionality doesn't seem to be getting much use in the wild, because this has been broken for a while and no one's stepped up, but I need it for https://github.com/yn/gmail-splitter, so here goes:

1) This worked when this file looked like the original version mentioned in the comment (https://github.com/oxos/gmail-oauth-thread-stats/blob/master/gmail_imap_extensions_compatibility.rb) but that version didn't parse spaces in labels correctly. 

2) The version of imap_extensions.rb prior to this PR claimed to parse spaces correctly, but it had no specs and a gnarly off-by-one error that caused parsing errors and extraneous parens in parsed label names. 

3) This PR fixed parsing errors and extraneous parens, and adds tests. The server_response lines in the spec have been copied directly from the wire. 

4) The original version referenced in (1) would do the following: If GMail sent down "\\Inbox" or "\\Important" in a label, it would convert it to a symbol like :Inbox  or :Important

5) This PR also restores that functionality. 

