### PR TITLE
Update README.md to clarify time-based filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ gmail.inbox.find(:unread).each do |email|
 end
 ```
 
+Note: The `:before` and `:after` filters only go as far as to search for messages on the date:
+
+```ruby
+# E.g. the following will return messages between 2016-01-01 00:00:00 and 2016-04-05 00:00:00
+gmail.inbox.find(
+    :after => Time.parse('2016-01-01 07:50:21'),
+    :before => Time.parse('2016-04-05 21:55:05')
+    )
+```
+
 ### Working with emails!
 
 Any news older than 4-20, mark as read and archive it:


### PR DESCRIPTION
Added an example to the README to show how the the `:before` and `:after` time-based filters work.

I felt it necessary, as I spent quite some time trying to work out why my time-based filters were not returning the expected set of messages, only to realise that the aforementioned filters only filter on the date of the provided `Time` or `Date` object.

It's not just myself that's been caught out by this: #198.