### PR TITLE
Fix Object#to_imap_date to use short month names

### DIFF
--- a/lib/gmail.rb
+++ b/lib/gmail.rb
@@ -11,7 +11,7 @@ end
 class Object
   def to_imap_date
     date = respond_to?(:utc) ? utc.to_s : to_s
-    Date.parse(date).strftime("%d-%B-%Y")
+    Date.parse(date).strftime("%d-%b-%Y")
   end
 end
 

--- a/spec/gmail_spec.rb
+++ b/spec/gmail_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Gmail do
   it "should be able to convert itself to IMAP date format" do
-    expect("20-12-1988".to_imap_date).to eq("20-December-1988")
+    expect("20-12-1988".to_imap_date).to eq("20-Dec-1988")
   end
 
   %w[new new!].each do |method|


### PR DESCRIPTION
Before, full month names were used and GMail accepted them.
But GMail changed this behavior and now only accepts date
queries that comply with the RFC 3501 which dictates to
use short month names.

Fixes https://github.com/gmailgem/gmail/issues/228
