### PR TITLE
Faster archiving methods

### DIFF
--- a/lib/gmail.rb
+++ b/lib/gmail.rb
@@ -11,7 +11,7 @@ end
 class Object
   def to_imap_date
     date = respond_to?(:utc) ? utc.to_s : to_s
-    Date.parse(date).strftime("%d-%B-%Y")
+    Date.parse(date).strftime("%d-%b-%Y")
   end
 end
 

--- a/lib/gmail/client.rb
+++ b/lib/gmail/client.rb
@@ -8,6 +8,8 @@ module Gmail
     class DeliveryError < ArgumentError; end
     # Raised when given client is not registered
     class UnknownClient < ArgumentError; end
+    # Raised when email not found
+    class EmailNotFound < ArgumentError; end
 
     def self.clients
       @clients ||= {}

--- a/lib/gmail/client/base.rb
+++ b/lib/gmail/client/base.rb
@@ -184,6 +184,13 @@ module Gmail
         mailbox("INBOX")
       end
 
+      # Functionality like rails #find method
+      def find(message_id)
+        mailbox('[Gmail]/All Mail').emails(message_id: message_id).first.tap do |message|
+          raise EmailNotFound, "Can't find message with ID #{message_id}" unless message
+        end
+      end
+
       def mailboxes
         @mailboxes ||= {}
       end

--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -44,7 +44,6 @@ module Gmail
         opts[:body]       and search.concat ['BODY', opts[:body]]
         opts[:uid]        and search.concat ['UID', opts[:uid]]
         opts[:gm]         and search.concat ['X-GM-RAW', opts[:gm]]
-        opts[:message_id] and search.concat ['X-GM-MSGID', opts[:message_id].to_s]
         opts[:query]      and search.concat opts[:query]
 
         @gmail.mailbox(name) do

--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -44,6 +44,7 @@ module Gmail
         opts[:body]       and search.concat ['BODY', opts[:body]]
         opts[:uid]        and search.concat ['UID', opts[:uid]]
         opts[:gm]         and search.concat ['X-GM-RAW', opts[:gm]]
+        opts[:message_id] and search.concat ['X-GM-MSGID', opts[:message_id].to_s]
         opts[:query]      and search.concat opts[:query]
 
         @gmail.mailbox(name) do

--- a/lib/gmail/message.rb
+++ b/lib/gmail/message.rb
@@ -123,18 +123,18 @@ module Gmail
     # from the list of labels.
     # If you selected a different mailbox then you would see '\\\\Inbox' in your results:
     def archive!
-      @gmail.find(message_id).remove_label("\\Inbox")
+      @gmail.find(message.message_id).remove_label('\Inbox')
     end
 
     def unarchive!
-      @gmail.find(message_id).add_label("\\Inbox")
+      @gmail.find(message.message_id).add_label('\Inbox')
     end
     alias_method :unspam!, :unarchive!
     alias_method :undelete!, :unarchive!
 
     def move_to(name, from = nil)
       add_label(name)
-      @gmail.find(message_id).remove_label(from) if from
+      @gmail.find(message.message_id).remove_label(from) if from
     end
     alias_method :move, :move_to
     alias_method :move!, :move_to

--- a/lib/gmail/message.rb
+++ b/lib/gmail/message.rb
@@ -123,15 +123,11 @@ module Gmail
     # from the list of labels.
     # If you selected a different mailbox then you would see '\\\\Inbox' in your results:
     def archive!
-      inbox_labeled_email do |email|
-        email.remove_label("\\Inbox")
-      end
+      @gmail.find(message_id).remove_label("\\Inbox")
     end
 
     def unarchive!
-      inbox_labeled_email do |email|
-        email.add_label("\\Inbox")
-      end
+      @gmail.find(message_id).add_label("\\Inbox")
     end
     alias_method :unspam!, :unarchive!
     alias_method :undelete!, :unarchive!
@@ -190,24 +186,6 @@ module Gmail
     end
 
     private
-
-    def temp_uuid_folder
-      uuid = SecureRandom.uuid
-      @gmail.labels.create uuid
-      add_label uuid
-
-      yield uuid
-    ensure
-      @gmail.labels.delete uuid
-    end
-
-    def inbox_labeled_email
-      temp_uuid_folder do |uuid|
-        email = @gmail.mailbox(uuid).emails(message_id: message_id).first
-        raise Gmail::Client::EmailNotFound, "Can't find message with ID #{message_id}" unless email
-        yield email
-      end
-    end
 
     def clear_cached_attributes
       @_attrs   = nil

--- a/lib/gmail/message.rb
+++ b/lib/gmail/message.rb
@@ -115,12 +115,19 @@ module Gmail
 
     # Archiving is done by adding the `\Trash` label. To undo this,
     # you just re-apply the `\Inbox` label (see `#unarchive!`)
+    #
+    # IMAP's fetch('1:100', (X-GM-LABELS)) function does not fetch inbox, just emails labeled important?
+    # http://stackoverflow.com/a/28973760
+    # In my testing the currently selected mailbox is always excluded from the X-GM-LABELS results.
+    # When you called conn.select() it implicitly selected 'INBOX', therefore excluding 'Inbox'
+    # from the list of labels.
+    # If you selected a different mailbox then you would see '\\\\Inbox' in your results:
     def archive!
-      remove_label("\\Inbox")
+      @gmail.find(message_id).remove_label("\\Inbox")
     end
 
     def unarchive!
-      add_label("\\Inbox")
+      @gmail.find(message_id).add_label("\\Inbox")
     end
     alias_method :unspam!, :unarchive!
     alias_method :undelete!, :unarchive!

--- a/lib/gmail/message.rb
+++ b/lib/gmail/message.rb
@@ -204,7 +204,7 @@ module Gmail
     def inbox_labeled_email
       temp_uuid_folder do |uuid|
         email = @gmail.mailbox(uuid).emails(message_id: message_id).first
-        raise EmailNotFound, "Can't find message with ID #{message_id}" unless email
+        raise Gmail::Client::EmailNotFound, "Can't find message with ID #{message_id}" unless email
         yield email
       end
     end

--- a/lib/gmail/message.rb
+++ b/lib/gmail/message.rb
@@ -125,14 +125,9 @@ module Gmail
     alias_method :unspam!, :unarchive!
     alias_method :undelete!, :unarchive!
 
-    # Move to given box and delete from others.
-    # Apply a given label and optionally remove one.
-    # TODO: We should probably deprecate this method. It doesn't really add a lot
-    #       of value, especially since the concept of "moving" a message from one
-    #       label to another doesn't totally make sense in the Gmail world.
     def move_to(name, from = nil)
       add_label(name)
-      remove_label(from) if from
+      @gmail.find(message_id).remove_label(from) if from
     end
     alias_method :move, :move_to
     alias_method :move!, :move_to

--- a/spec/gmail_spec.rb
+++ b/spec/gmail_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Gmail do
   it "should be able to convert itself to IMAP date format" do
-    expect("20-12-1988".to_imap_date).to eq("20-December-1988")
+    expect("20-12-1988".to_imap_date).to eq("20-Dec-1988")
   end
 
   %w[new new!].each do |method|


### PR DESCRIPTION
`mailbox('[Gmail]/All Mail')` can be deadly slow when you have full of emails.
This will fix that by 
1. create a temp folder (label)
2. put the target email in it
3. archive it or unarchive it
4. delete the temp folder
