### PR TITLE
Added message_id to search params

### DIFF
--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -44,6 +44,7 @@ module Gmail
         opts[:body]       and search.concat ['BODY', opts[:body]]
         opts[:uid]        and search.concat ['UID', opts[:uid]]
         opts[:gm]         and search.concat ['X-GM-RAW', opts[:gm]]
+        opts[:message_id] and search.concat ['X-GM-MSGID', opts[:message_id].to_s]
         opts[:query]      and search.concat opts[:query]
 
         @gmail.mailbox(name) do


### PR DESCRIPTION
Tested and works - useful instead of Gmail API get message request in certain cases.