### PR TITLE
Update mailbox.rb

### DIFF
--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -32,9 +32,9 @@ module Gmail
         search = MAILBOX_ALIASES[args.shift].dup
         opts = args.first.is_a?(Hash) ? args.first : {}
 
-        opts[:after]      and search.concat ['SINCE', opts[:after].to_imap_date]
-        opts[:before]     and search.concat ['BEFORE', opts[:before].to_imap_date]
-        opts[:on]         and search.concat ['ON', opts[:on].to_imap_date]
+        opts[:after]      and search.concat ['SINCE', Net::IMAP.format_date(opts[:after])]
+        opts[:before]     and search.concat ['BEFORE', Net::IMAP.format_date(opts[:before])]
+        opts[:on]         and search.concat ['ON', Net::IMAP.format_date(opts[:on])]
         opts[:from]       and search.concat ['FROM', opts[:from]]
         opts[:to]         and search.concat ['TO', opts[:to]]
         opts[:subject]    and search.concat ['SUBJECT', opts[:subject]]


### PR DESCRIPTION
XXX.to_imap_date  causes "'get_tagged_response': Could not parse command (Net::IMAP::BadResponseError)".
Please use "Net::IMAP.format_date".