### PR TITLE
Use Net::IMAP.format_date instead of to_imap_date

### DIFF
--- a/lib/gmail.rb
+++ b/lib/gmail.rb
@@ -8,13 +8,6 @@ if RUBY_VERSION < "1.8.7"
   require "smtp_tls"
 end
 
-class Object
-  def to_imap_date
-    date = respond_to?(:utc) ? utc.to_s : to_s
-    Date.parse(date).strftime("%d-%b-%Y")
-  end
-end
-
 module Gmail
   autoload :Version, "gmail/version"
   autoload :Client,  "gmail/client"

--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -32,8 +32,8 @@ module Gmail
         search = MAILBOX_ALIASES[args.shift].dup
         opts = args.first.is_a?(Hash) ? args.first : {}
 
-        opts[:after]      and search.concat ['SINCE', opts[:after].to_imap_date]
-        opts[:before]     and search.concat ['BEFORE', opts[:before].to_imap_date]
+        opts[:after]      and search.concat ['SINCE', Net::IMAP.format_date(opts[:after])]
+        opts[:before]     and search.concat ['BEFORE', Net::IMAP.format_date(opts[:before])]
         opts[:on]         and search.concat ['ON', opts[:on].to_imap_date]
         opts[:from]       and search.concat ['FROM', opts[:from]]
         opts[:to]         and search.concat ['TO', opts[:to]]

--- a/spec/gmail_spec.rb
+++ b/spec/gmail_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
+require 'net/imap'
 
 describe Gmail do
   it "should be able to convert itself to IMAP date format" do
-    expect("20-12-1988".to_imap_date).to eq("20-Dec-1988")
+    expect(Net::IMAP.format_date(Date.new(1988, 12, 20))).to eq("20-Dec-1988")
   end
 
   %w[new new!].each do |method|


### PR DESCRIPTION
Use `Net::IMAP.format_date` instead of `to_imap_date`.

See https://github.com/gmailgem/gmail/pull/244#issuecomment-405390645