### PR TITLE
Add support for charset attribute in search

### DIFF
--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -48,7 +48,7 @@ module Gmail
         opts[:query]      and search.concat opts[:query]
 
         @gmail.mailbox(name) do
-          @gmail.conn.uid_search(search)
+          @gmail.conn.uid_search(search, opts[:charset])
         end
       elsif args.first.is_a?(Hash)
         fetch_uids(:all, args.first)


### PR DESCRIPTION
This allows to use non-ascii characters in search, e.g. `Café `

With this fix can be used as:
```ruby
gmail.inbox.emails(gm: "Café".force_encoding('ascii-8bit'), charset: "UTF-8")
```

---

Solution inspired by https://github.com/dcparker/ruby-gmail/issues/81

Would it be nice to apply `UTF-8` as charset automatically?