### PR TITLE
Fix compatibility with `ruby-3.1` by adding bundled gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Gmail Gem Changelog
 
+## unreleased
+
+* Fix compatibility with `ruby-3.1` by adding bundled gems
+
 ## 0.7.1 - 2018-07-19
 
 * Fix issue related to Net::IMAP.format_date change (@mnohai-mdsol)

--- a/gmail.gemspec
+++ b/gmail.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |s|
   # runtime dependencies
   s.add_dependency "gmail_xoauth", ">= 0.3.0"
   s.add_dependency "mail", ">= 2.2.1"
+  s.add_dependency "net-imap", "~> 0"
+  s.add_dependency "net-smtp", "~> 0"
 
   # development dependencies
   s.add_development_dependency "gem-release"


### PR DESCRIPTION
Since this ruby release `net-imap` and `net-smtp`
are not required by default

See ruby changelog [here](https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/)
This fix errors like this:
```
LoadError: cannot load such file -- net/imap
/home/user/.rvm/gems/ruby-3.1.0/gems/gmail-0.7.1/lib/gmail.rb:1:in `require'
/home/user/.rvm/gems/ruby-3.1.0/gems/gmail-0.7.1/lib/gmail.rb:1:in `<top (required)>'

```